### PR TITLE
header 스타일 수정 + 재사용성 추가

### DIFF
--- a/itda-front/src/components/Home/Home.tsx
+++ b/itda-front/src/components/Home/Home.tsx
@@ -6,7 +6,7 @@ import BrandStory from "./BrandStory";
 const Home = () => {
 	return (
 		<S.Home.HomeContainer>
-			<Header></Header>
+			<Header color={'#ffffff'}></Header>
 			{/* <S.Home.HeroLayer></S.Home.HeroLayer> */}
 			<Hero />
 			<BrandStory />

--- a/itda-front/src/components/Products/Products.tsx
+++ b/itda-front/src/components/Products/Products.tsx
@@ -4,7 +4,7 @@ import ProductList from "./ProductList";
 const Products = () => {
 	return (
 		<>
-			<Header />
+			<Header color={'#555555'}/>
 			<Navigator />
 			<ProductList />
 		</>

--- a/itda-front/src/components/common/CommonStyles.tsx
+++ b/itda-front/src/components/common/CommonStyles.tsx
@@ -9,17 +9,22 @@ const S = {
     HeaderContainer: styled.div`
       display: flex;
       justify-content: center;
-      font-family: "Gowun Batang", serif;
+      height: 100px;
+      font-family: "Gowun Dodum", serif;
     `,
 
     HeaderLayout: styled.div`
       display: flex;
+      min-width: 1200px;
       width: 80%;
     `,
 
     LeftBlock: styled.div`
       display: flex;
       width: 50%;
+      & > nav {
+        color: ${({color}) => color};
+      };
     `,
 
     Navigation: styled.nav`
@@ -27,12 +32,12 @@ const S = {
       width: calc(100% / 4);
       margin: auto 0;
       cursor: pointer;
+      font-size: ${({theme})=> theme.fontSizes.base};
     `,
 
     LogoBlock: styled.div`
       display: flex;
       align-items: center;
-      height: 10rem;
       & > svg {
         cursor: pointer;
       }
@@ -49,11 +54,33 @@ const S = {
       }
     `,
 
-    ItdaLogo: styled(itdaLogo)``,
+    ItdaLogo: styled(itdaLogo)`
+      height: 70px;
+      width: auto;
+      & path {
+        fill: ${({color}) => color};
+      }
+      & line {
+        stroke: ${({color}) => color};
+      }
+    `,
 
-    CartButton: styled(cartIcon)``,
+    CartButton: styled(cartIcon)`
+      height: 40px;
+      width: auto;
+      stroke: ${({color}) => color};
+      & path {
+        fill: ${({color}) => color}
+      }
+    `,
 
-    LoginButton: styled(loginIcon)``,
+    LoginButton: styled(loginIcon)`
+      height: 40px;
+      width: auto;
+      & path {
+        stroke: ${({color}) => color};
+      }
+    `,
   },
 
   ProductCard: {

--- a/itda-front/src/components/common/Header/Header.tsx
+++ b/itda-front/src/components/common/Header/Header.tsx
@@ -1,21 +1,25 @@
 import S from "../CommonStyles";
 import SideDrawer from "./SideDrawer";
 
-const Header = () => {
+type HeaderPropType = {
+	color: string;
+}
+
+const Header = ({ color } : HeaderPropType) => {
 	return (
 		<S.Header.HeaderContainer>
 			<S.Header.HeaderLayout>
-				<S.Header.LeftBlock>
+				<S.Header.LeftBlock color={color}>
 						<S.Header.Navigation>홈</S.Header.Navigation>
 						<S.Header.Navigation>제품 소개</S.Header.Navigation>
 						<S.Header.Navigation>브랜드 이야기</S.Header.Navigation>
 				</S.Header.LeftBlock>
 				<S.Header.LogoBlock>
-					<S.Header.ItdaLogo/>
+					<S.Header.ItdaLogo color={color}/>
 				</S.Header.LogoBlock>
 				<S.Header.RightBlock>
-					<S.Header.CartButton/>
-					<S.Header.LoginButton/>
+					<S.Header.CartButton color={color}/>
+					<S.Header.LoginButton color={color}/>
 				</S.Header.RightBlock>
 			</S.Header.HeaderLayout>
 		</S.Header.HeaderContainer>


### PR DESCRIPTION
## 📌 개요
Resolved #22 
브라우저의 창크기를 다르게 하면 header의 전반적인 사이즈와 스타일이 유지되지 않는 문제 해결

## 👩‍💻 작업 사항

- [x] header 재사용성 높이기:  페이지별로 color옵션을 prop로 전달 받아서 색상을 custom할 수 있게 변경.
- [x] header 타입 설정하기
- [x] 창 크기 변화에도 스타일 유지할 수 있게 하기
- [x] header 전체적인 크기 줄이기 


## ✅ 참고 사항

공유할 내용, 스크린샷 등을 넣어 주세요.
<전체 화면>
![image](https://user-images.githubusercontent.com/65105537/127767757-73f678d0-34cd-4c1a-9b71-e32ac383bd7e.png)


<창을 줄였을 때>
![image](https://user-images.githubusercontent.com/65105537/127767767-f81ac86a-7043-4d70-92f3-50ca7bd76086.png)

<최대로 줄였을 때>
![image](https://user-images.githubusercontent.com/65105537/127767784-9cd3e0fa-cd73-4c5d-afcf-49bf27cb26a1.png)
