### PR TITLE
[Feat] Product Detail 페이지 기능 일부 구현

### DIFF
--- a/itda-front/src/components/ProductDetail/ProductDescription.tsx
+++ b/itda-front/src/components/ProductDetail/ProductDescription.tsx
@@ -1,0 +1,5 @@
+const ProductDescription = () => {
+  return <div>상품 설명</div>;
+};
+
+export default ProductDescription;

--- a/itda-front/src/components/ProductDetail/ProductDescription.tsx
+++ b/itda-front/src/components/ProductDetail/ProductDescription.tsx
@@ -1,5 +1,5 @@
 const ProductDescription = () => {
-  return <div>상품 설명</div>;
+  return <h1>상품 설명</h1>;
 };
 
 export default ProductDescription;

--- a/itda-front/src/components/ProductDetail/ProductDetail.tsx
+++ b/itda-front/src/components/ProductDetail/ProductDetail.tsx
@@ -1,14 +1,17 @@
 import Header from "components/common/Header";
 import ProductInfo from "./ProductInfo";
 import ProductTab from "./ProductTab";
+import S from "./ProductDetailStyles";
 
 const ProductDetail = () => {
   return (
-    <div>
+    <>
       <Header color="#55555" />
-      <ProductInfo />
-      <ProductTab />
-    </div>
+      <S.ProductDetailWall>
+        <ProductInfo />
+        <ProductTab />
+      </S.ProductDetailWall>
+    </>
   );
 };
 

--- a/itda-front/src/components/ProductDetail/ProductDetail.tsx
+++ b/itda-front/src/components/ProductDetail/ProductDetail.tsx
@@ -1,5 +1,15 @@
+import Header from "components/common/Header";
+import ProductInfo from "./ProductInfo";
+import ProductTab from "./ProductTab";
+
 const ProductDetail = () => {
-	return <div></div>;
+  return (
+    <div>
+      <Header color="#55555" />
+      <ProductInfo />
+      <ProductTab />
+    </div>
+  );
 };
 
 export default ProductDetail;

--- a/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
+++ b/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
@@ -164,6 +164,41 @@ const S = {
       background: ${({ theme }) => theme.colors.navy.light};
     `,
   },
+  ProductTab: {
+    TabLayout: styled.div`
+      display: flex;
+      flex-direction: column;
+      width: 1050px;
+      margin: 5rem auto;
+    `,
+
+    TabToggleLayer: styled.div`
+      display: flex;
+      border: 1px solid #eee;
+      width: 100%;
+      font-size: 1.5rem;
+      &:hover {
+        cursor: pointer;
+      }
+    `,
+
+    InformationTabBlock: styled.div`
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 50%;
+      height: 6rem;
+      background: #e2e2e2;
+    `,
+
+    ReviewTabBlock: styled.div`
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 50%;
+      height: 6rem;
+    `,
+  },
 };
 
 export default S;

--- a/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
+++ b/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
@@ -1,0 +1,3 @@
+const S = {};
+
+export default S;

--- a/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
+++ b/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
@@ -85,6 +85,26 @@ const S = {
       margin: 1rem 0 0 0;
     `,
 
+    DetailCountDiv: styled.div`
+      display: flex;
+      width: 6rem;
+      height: 2rem;
+      border: 1px solid #dddfe1;
+      border-radius: 4px;
+      div {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 3rem;
+      }
+      button {
+        width: 3rem;
+        color: #333;
+        background: none;
+        font-weight: bold;
+      }
+    `,
+
     DetailTotalPriceDiv: styled.div`
       font-size: 0.8rem;
       margin-top: 1.1rem;

--- a/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
+++ b/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
@@ -1,3 +1,169 @@
-const S = {};
+import styled from "styled-components";
+
+const S = {
+  ProductDetailWall: styled.div`
+    width: 100%;
+    height: fit-content;
+  `,
+
+  ProductInfo: {
+    InfoLayout: styled.div`
+      display: flex;
+      flex-direction: column;
+      margin: 0 auto;
+      padding: 1.3rem 0 0 0;
+      width: 1050px;
+      height: fit-content;
+    `,
+
+    ProductDetailLayer: styled.div`
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+    `,
+
+    ImageBlock: styled.img`
+      width: 27rem;
+      height: 34.5rem;
+    `,
+
+    DetailBlock: styled.div`
+      display: flex;
+      flex-direction: column;
+      /* width: 35rem; */
+      justify-content: space-between;
+    `,
+
+    DetailName: styled.span`
+      font-weight: bold;
+      font-size: 1.5rem;
+      margin: 0.6rem 0;
+    `,
+    DetailShortInfo: styled.span`
+      color: #999999;
+      font-size: 0.8rem;
+    `,
+    DetailPrice: styled.span`
+      font-weight: bold;
+      font-size: 1.75rem;
+      padding: 1.8rem 0 1.5rem 0;
+      border-bottom: 1px solid #f4f4f4;
+    `,
+
+    DetailProductInfo: styled.ul`
+      padding: 0;
+      color: #666;
+      font-size: 0.87rem;
+      li {
+        padding: 1.1rem 0;
+        border-bottom: 1px solid #f4f4f4;
+        &:nth-child(1) {
+          dl {
+            &:first-child {
+              margin-bottom: 1rem;
+            }
+          }
+        }
+      }
+      dl {
+        margin: 0;
+        display: flex;
+
+        dt {
+          width: 9rem;
+        }
+        dd {
+          margin: 0;
+          width: 25rem;
+        }
+      }
+    `,
+
+    DetailBuyBlock: styled.div`
+      display: flex;
+      justify-content: space-between;
+      margin: 1rem 0 0 0;
+    `,
+
+    DetailTotalPriceDiv: styled.div`
+      font-size: 0.8rem;
+      margin-top: 1.1rem;
+    `,
+
+    DetailTotalPrice: styled.span`
+      font-weight: bold;
+      font-size: 1.5rem;
+      margin-left: 0.2rem;
+    `,
+
+    ProductPaymentLayer: styled.div`
+      display: flex;
+      justify-content: space-between;
+      width: 100%;
+      height: fit-content;
+      margin-top: 1.5rem;
+    `,
+
+    SellerBlock: styled.div`
+      display: flex;
+      width: 27rem;
+    `,
+
+    SellerImageWrapper: styled.div`
+      width: 7rem;
+      height: 7rem;
+      border: 1px solid #999999;
+      border-radius: 70%;
+      overflow: hidden;
+    `,
+
+    SellerImage: styled.img`
+      width: 7rem;
+      height: 7rem;
+      padding: 0.4rem;
+    `,
+
+    SellerInfo: styled.div`
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      margin-left: 1rem;
+    `,
+
+    SellerName: styled.span`
+      margin-bottom: 0.5rem;
+      font-size: 1.5rem;
+      font-weight: bold;
+    `,
+
+    SellerDetail: styled.span`
+      font-size: 0.9rem;
+      color: #666;
+    `,
+
+    PaymentBlock: styled.div`
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    `,
+
+    AddToCartButton: styled.button`
+      width: 20rem;
+      height: 3rem;
+      color: white;
+      font-weight: bold;
+      border-radius: 4px;
+      background: ${({ theme }) => theme.colors.skyBlue.normal};
+    `,
+    BuyButton: styled.button`
+      width: 20rem;
+      height: 3rem;
+      color: white;
+      font-weight: bold;
+      border-radius: 4px;
+      background: ${({ theme }) => theme.colors.navy.light};
+    `,
+  },
+};
 
 export default S;

--- a/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
+++ b/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
@@ -174,7 +174,7 @@ const S = {
 
     TabToggleLayer: styled.div`
       display: flex;
-      border: 1px solid #eee;
+      border-top: 1px solid #eee;
       width: 100%;
       font-size: 1.5rem;
       &:hover {
@@ -182,21 +182,26 @@ const S = {
       }
     `,
 
-    InformationTabBlock: styled.div`
+    InformationTabBlock: styled.div<{ isInfo: boolean }>`
       display: flex;
       justify-content: center;
       align-items: center;
       width: 50%;
       height: 6rem;
-      background: #e2e2e2;
+      ${({ isInfo }) => (isInfo ? `background: none;` : `background: #e2e2e2;`)}
     `,
 
-    ReviewTabBlock: styled.div`
+    ReviewTabBlock: styled.div<{ isInfo: boolean }>`
       display: flex;
       justify-content: center;
       align-items: center;
       width: 50%;
       height: 6rem;
+      ${({ isInfo }) =>
+        isInfo
+          ? `background: #e2e2e2;`
+          : `background: none;
+      `}
     `,
   },
 };

--- a/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
+++ b/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
@@ -78,13 +78,6 @@ const S = {
         }
       }
     `,
-
-    DetailBuyBlock: styled.div`
-      display: flex;
-      justify-content: space-between;
-      margin: 1rem 0 0 0;
-    `,
-
     DetailCountDiv: styled.div`
       display: flex;
       width: 6rem;
@@ -104,10 +97,19 @@ const S = {
         font-weight: bold;
       }
     `,
-
-    DetailTotalPriceDiv: styled.div`
+    DetailBuyBlock: styled.div`
+      display: flex;
+      justify-content: flex-end;
+      align-items: flex-end;
+      margin: 2.1rem 0 0 0;
       font-size: 0.8rem;
-      margin-top: 1.1rem;
+    `,
+
+    DetailPriceDiv: styled.div`
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-end;
+      width: 11.8rem;
     `,
 
     DetailTotalPrice: styled.span`

--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -1,45 +1,91 @@
+import S from "./ProductDetailStyles";
+
 const ProductInfo = () => {
   return (
-    <>
-      <div>
-        <div>
-          <img
-            src="https://freshleader.co.kr/data/item/1f8_1060_0008/thumb-1f8_1_450x520.jpg"
-            alt="상품 이미지"
-          />
-        </div>
-        <div>
-          <div>크롱의 흙당근 2kg</div>
-          <div>제주 바다 바람을 품은 친환경 흙당근</div>
-          <div>19,900원</div>
-          <div>
-            <div>판매 단위 1봉지</div>
-            <div>중량/용량 500g(2~4개입)</div>
-            <div>배송 2,500원 (30,000원 이상 무료 배송)</div>
-            <div>원산지 제주</div>
-            <div>포장타입 냉장/종이포장</div>
-            <div>안내사항 -식품 특성상 중량은 5%내외의 차이가 있습니다.</div>
-          </div>
-          <div>
+    <S.ProductInfo.InfoLayout>
+      <S.ProductInfo.ProductDetailLayer>
+        <S.ProductInfo.ImageBlock
+          src="https://freshleader.co.kr/data/item/1f8_1060_0008/thumb-1f8_1_450x520.jpg"
+          alt="상품 이미지"
+        />
+        <S.ProductInfo.DetailBlock>
+          <S.ProductInfo.DetailName>크롱의 흙당근 2kg</S.ProductInfo.DetailName>
+          <S.ProductInfo.DetailShortInfo>
+            제주 바다 바람을 품은 친환경 흙당근
+          </S.ProductInfo.DetailShortInfo>
+          <S.ProductInfo.DetailPrice>19,900원</S.ProductInfo.DetailPrice>
+          <S.ProductInfo.DetailProductInfo>
+            <li>
+              <dl>
+                <dt>판매 단위</dt>
+                <dd>1봉지</dd>
+              </dl>
+              <dl>
+                <dt>중량/용량</dt>
+                <dd>500g(2~4개입)</dd>
+              </dl>
+            </li>
+            <li>
+              <dl>
+                <dt>배송</dt>
+                <dd>2,500원 (30,000원 이상 무료 배송)</dd>
+              </dl>
+            </li>
+            <li>
+              <dl>
+                <dt>원산지</dt>
+                <dd>제주</dd>
+              </dl>
+            </li>
+            <li>
+              <dl>
+                <dt>포장타입</dt>
+                <dd>냉장/종이포장</dd>
+              </dl>
+            </li>
+            <li>
+              <dl>
+                <dt>안내사항</dt>
+                <dd>식품 특성상 중량은 5%내외의 차이가 있습니다.</dd>
+              </dl>
+            </li>
+          </S.ProductInfo.DetailProductInfo>
+          <S.ProductInfo.DetailBuyBlock>
             <div>수량조절버튼</div>
-            <div>총 상품 금액:19,900</div>
-          </div>
-        </div>
-      </div>
-      <div>
-        <div>
-          <img alt="판매자사진" />
-          <div>
-            <div>크롱에게 문의하기</div>
-            <div>신선한 제품을 재배합니다</div>
-          </div>
-        </div>
-        <div>
-          <button>장바구니 담기</button>
-          <button>구매하기</button>
-        </div>
-      </div>
-    </>
+            <S.ProductInfo.DetailTotalPriceDiv>
+              총 상품 금액:
+              <S.ProductInfo.DetailTotalPrice>
+                19,900원
+              </S.ProductInfo.DetailTotalPrice>
+            </S.ProductInfo.DetailTotalPriceDiv>
+          </S.ProductInfo.DetailBuyBlock>
+        </S.ProductInfo.DetailBlock>
+      </S.ProductInfo.ProductDetailLayer>
+      <S.ProductInfo.ProductPaymentLayer>
+        <S.ProductInfo.SellerBlock>
+          <S.ProductInfo.SellerImageWrapper>
+            <S.ProductInfo.SellerImage
+              src="http://img.segye.com/content/image/2021/07/29/20210729513138.jpg"
+              alt="판매자사진"
+            />
+          </S.ProductInfo.SellerImageWrapper>
+          <S.ProductInfo.SellerInfo>
+            <S.ProductInfo.SellerName>
+              크롱에게 문의하기
+            </S.ProductInfo.SellerName>
+            <S.ProductInfo.SellerDetail>
+              "신선한 제품을 재배합니다"
+            </S.ProductInfo.SellerDetail>
+          </S.ProductInfo.SellerInfo>
+        </S.ProductInfo.SellerBlock>
+        <S.ProductInfo.PaymentBlock>
+          <S.ProductInfo.AddToCartButton>
+            장바구니 담기
+          </S.ProductInfo.AddToCartButton>
+          <S.ProductInfo.BuyButton>구매하기</S.ProductInfo.BuyButton>
+        </S.ProductInfo.PaymentBlock>
+      </S.ProductInfo.ProductPaymentLayer>
+    </S.ProductInfo.InfoLayout>
   );
 };
 

--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -3,15 +3,41 @@ const ProductInfo = () => {
     <>
       <div>
         <div>
-          <img alt="상품 이미지" />
+          <img
+            src="https://freshleader.co.kr/data/item/1f8_1060_0008/thumb-1f8_1_450x520.jpg"
+            alt="상품 이미지"
+          />
         </div>
         <div>
-          <div>상품 설명</div>
+          <div>크롱의 흙당근 2kg</div>
+          <div>제주 바다 바람을 품은 친환경 흙당근</div>
+          <div>19,900원</div>
+          <div>
+            <div>판매 단위 1봉지</div>
+            <div>중량/용량 500g(2~4개입)</div>
+            <div>배송 2,500원 (30,000원 이상 무료 배송)</div>
+            <div>원산지 제주</div>
+            <div>포장타입 냉장/종이포장</div>
+            <div>안내사항 -식품 특성상 중량은 5%내외의 차이가 있습니다.</div>
+          </div>
+          <div>
+            <div>수량조절버튼</div>
+            <div>총 상품 금액:19,900</div>
+          </div>
         </div>
       </div>
       <div>
-        <div>크롱연락</div>
-        <div>장바구니 버튼2개부분</div>
+        <div>
+          <img alt="판매자사진" />
+          <div>
+            <div>크롱에게 문의하기</div>
+            <div>신선한 제품을 재배합니다</div>
+          </div>
+        </div>
+        <div>
+          <button>장바구니 담기</button>
+          <button>구매하기</button>
+        </div>
       </div>
     </>
   );

--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -1,50 +1,79 @@
 import { useRecoilState } from "recoil";
 import { detailProductCount } from "stores/ProductDetailAtoms";
+import { IProductDetail } from "types/ProductDetailTypes";
 import S from "./ProductDetailStyles";
 
 const ProductInfo = () => {
   const [productCount, setProductCount] = useRecoilState(detailProductCount);
-
+  const mockProduct: IProductDetail = {
+    id: 1,
+    name: "흙당근",
+    imageUrl:
+      "https://freshleader.co.kr/data/item/1f8_1060_0008/thumb-1f8_1_450x520.jpg",
+    description: "제주 바다 바람을 품은 친환경 흙당근",
+    price: 19900,
+    salesUnit: "1봉지",
+    weight: "500g (2~4개입)",
+    deliveryFee: 2500,
+    deliveryFeeCondition: "30,000원 이상 무료 배송",
+    origin: "제주",
+    packagingType: "냉장/종이포장",
+    detailDescription: "###제목<br><p>내용들어가고 어쩌고</p>",
+    seller: {
+      id: 1,
+      name: "박크롱",
+      imageUrl:
+        "http://img.segye.com/content/image/2021/07/29/20210729513138.jpg",
+      description: "신선한 제품을 재배합니다.",
+    },
+  };
   return (
     <S.ProductInfo.InfoLayout>
       <S.ProductInfo.ProductDetailLayer>
         <S.ProductInfo.ImageBlock
-          src="https://freshleader.co.kr/data/item/1f8_1060_0008/thumb-1f8_1_450x520.jpg"
+          src={mockProduct.imageUrl}
           alt="상품 이미지"
         />
         <S.ProductInfo.DetailBlock>
-          <S.ProductInfo.DetailName>크롱의 흙당근 2kg</S.ProductInfo.DetailName>
+          <S.ProductInfo.DetailName>
+            {mockProduct.name}
+          </S.ProductInfo.DetailName>
           <S.ProductInfo.DetailShortInfo>
-            제주 바다 바람을 품은 친환경 흙당근
+            {mockProduct.description}
           </S.ProductInfo.DetailShortInfo>
-          <S.ProductInfo.DetailPrice>19,900원</S.ProductInfo.DetailPrice>
+          <S.ProductInfo.DetailPrice>
+            {mockProduct.price}원
+          </S.ProductInfo.DetailPrice>
           <S.ProductInfo.DetailProductInfo>
             <li>
               <dl>
                 <dt>판매 단위</dt>
-                <dd>1봉지</dd>
+                <dd>{mockProduct.salesUnit}</dd>
               </dl>
               <dl>
                 <dt>중량/용량</dt>
-                <dd>500g(2~4개입)</dd>
+                <dd>{mockProduct.weight}</dd>
               </dl>
             </li>
             <li>
               <dl>
                 <dt>배송</dt>
-                <dd>2,500원 (30,000원 이상 무료 배송)</dd>
+                <dd>
+                  {mockProduct.deliveryFee}원 (
+                  {mockProduct.deliveryFeeCondition})
+                </dd>
               </dl>
             </li>
             <li>
               <dl>
                 <dt>원산지</dt>
-                <dd>제주</dd>
+                <dd>{mockProduct.origin}</dd>
               </dl>
             </li>
             <li>
               <dl>
                 <dt>포장타입</dt>
-                <dd>냉장/종이포장</dd>
+                <dd>{mockProduct.packagingType}</dd>
               </dl>
             </li>
             <li>
@@ -57,7 +86,7 @@ const ProductInfo = () => {
           <S.ProductInfo.DetailBuyBlock>
             <S.ProductInfo.DetailCountDiv>
               <button
-                disabled={productCount <= 0}
+                disabled={productCount <= 1}
                 onClick={() => setProductCount(productCount - 1)}
               >
                 -
@@ -70,7 +99,7 @@ const ProductInfo = () => {
             <S.ProductInfo.DetailTotalPriceDiv>
               총 상품 금액:
               <S.ProductInfo.DetailTotalPrice>
-                19,900원
+                {mockProduct.price * productCount}원
               </S.ProductInfo.DetailTotalPrice>
             </S.ProductInfo.DetailTotalPriceDiv>
           </S.ProductInfo.DetailBuyBlock>
@@ -80,7 +109,7 @@ const ProductInfo = () => {
         <S.ProductInfo.SellerBlock>
           <S.ProductInfo.SellerImageWrapper>
             <S.ProductInfo.SellerImage
-              src="http://img.segye.com/content/image/2021/07/29/20210729513138.jpg"
+              src={mockProduct.seller.imageUrl}
               alt="판매자사진"
             />
           </S.ProductInfo.SellerImageWrapper>

--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -78,30 +78,31 @@ const ProductInfo = () => {
             </li>
             <li>
               <dl>
-                <dt>안내사항</dt>
-                <dd>식품 특성상 중량은 5%내외의 차이가 있습니다.</dd>
+                <dt>구매 수량</dt>
+                <dd>
+                  <S.ProductInfo.DetailCountDiv>
+                    <button
+                      disabled={productCount <= 1}
+                      onClick={() => setProductCount(productCount - 1)}
+                    >
+                      -
+                    </button>
+                    <div>{productCount}</div>
+                    <button onClick={() => setProductCount(productCount + 1)}>
+                      +
+                    </button>
+                  </S.ProductInfo.DetailCountDiv>
+                </dd>
               </dl>
             </li>
           </S.ProductInfo.DetailProductInfo>
           <S.ProductInfo.DetailBuyBlock>
-            <S.ProductInfo.DetailCountDiv>
-              <button
-                disabled={productCount <= 1}
-                onClick={() => setProductCount(productCount - 1)}
-              >
-                -
-              </button>
-              <div>{productCount}</div>
-              <button onClick={() => setProductCount(productCount + 1)}>
-                +
-              </button>
-            </S.ProductInfo.DetailCountDiv>
-            <S.ProductInfo.DetailTotalPriceDiv>
-              총 상품 금액:
+            <S.ProductInfo.DetailPriceDiv>
+              <span>총 상품 금액:</span>
               <S.ProductInfo.DetailTotalPrice>
                 {mockProduct.price * productCount}원
               </S.ProductInfo.DetailTotalPrice>
-            </S.ProductInfo.DetailTotalPriceDiv>
+            </S.ProductInfo.DetailPriceDiv>
           </S.ProductInfo.DetailBuyBlock>
         </S.ProductInfo.DetailBlock>
       </S.ProductInfo.ProductDetailLayer>

--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -1,6 +1,10 @@
+import { useRecoilState } from "recoil";
+import { detailProductCount } from "stores/ProductDetailAtoms";
 import S from "./ProductDetailStyles";
 
 const ProductInfo = () => {
+  const [productCount, setProductCount] = useRecoilState(detailProductCount);
+
   return (
     <S.ProductInfo.InfoLayout>
       <S.ProductInfo.ProductDetailLayer>
@@ -51,7 +55,18 @@ const ProductInfo = () => {
             </li>
           </S.ProductInfo.DetailProductInfo>
           <S.ProductInfo.DetailBuyBlock>
-            <div>수량조절버튼</div>
+            <S.ProductInfo.DetailCountDiv>
+              <button
+                disabled={productCount <= 0}
+                onClick={() => setProductCount(productCount - 1)}
+              >
+                -
+              </button>
+              <div>{productCount}</div>
+              <button onClick={() => setProductCount(productCount + 1)}>
+                +
+              </button>
+            </S.ProductInfo.DetailCountDiv>
             <S.ProductInfo.DetailTotalPriceDiv>
               총 상품 금액:
               <S.ProductInfo.DetailTotalPrice>

--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -1,0 +1,20 @@
+const ProductInfo = () => {
+  return (
+    <>
+      <div>
+        <div>
+          <img alt="상품 이미지" />
+        </div>
+        <div>
+          <div>상품 설명</div>
+        </div>
+      </div>
+      <div>
+        <div>크롱연락</div>
+        <div>장바구니 버튼2개부분</div>
+      </div>
+    </>
+  );
+};
+
+export default ProductInfo;

--- a/itda-front/src/components/ProductDetail/ProductReview.tsx
+++ b/itda-front/src/components/ProductDetail/ProductReview.tsx
@@ -1,5 +1,5 @@
 const ProductReview = () => {
-  return <div>리뷰</div>;
+  return <h1>리뷰</h1>;
 };
 
 export default ProductReview;

--- a/itda-front/src/components/ProductDetail/ProductReview.tsx
+++ b/itda-front/src/components/ProductDetail/ProductReview.tsx
@@ -1,0 +1,5 @@
+const ProductReview = () => {
+  return <div>리뷰</div>;
+};
+
+export default ProductReview;

--- a/itda-front/src/components/ProductDetail/ProductTab.tsx
+++ b/itda-front/src/components/ProductDetail/ProductTab.tsx
@@ -1,18 +1,30 @@
+import { useRecoilState } from "recoil";
 import S from "./ProductDetailStyles";
 import ProductDescription from "./ProductDescription";
 import ProductReview from "./ProductReview";
+import { isTabStateDetailInfo } from "stores/ProductDetailAtoms";
 
 const ProductTab = () => {
+  const [isTabStateInfo, setTabStateInfo] =
+    useRecoilState(isTabStateDetailInfo);
+
   return (
     <S.ProductTab.TabLayout>
       <S.ProductTab.TabToggleLayer>
-        <S.ProductTab.InformationTabBlock>
+        <S.ProductTab.InformationTabBlock
+          isInfo={isTabStateInfo}
+          onClick={() => setTabStateInfo(true)}
+        >
           상품설명
         </S.ProductTab.InformationTabBlock>
-        <S.ProductTab.ReviewTabBlock>후기</S.ProductTab.ReviewTabBlock>
+        <S.ProductTab.ReviewTabBlock
+          isInfo={isTabStateInfo}
+          onClick={() => setTabStateInfo(false)}
+        >
+          후기
+        </S.ProductTab.ReviewTabBlock>
       </S.ProductTab.TabToggleLayer>
-      <ProductDescription />
-      <ProductReview />
+      {isTabStateInfo ? <ProductDescription /> : <ProductReview />}
     </S.ProductTab.TabLayout>
   );
 };

--- a/itda-front/src/components/ProductDetail/ProductTab.tsx
+++ b/itda-front/src/components/ProductDetail/ProductTab.tsx
@@ -1,0 +1,17 @@
+import ProductDescription from "./ProductDescription";
+import ProductReview from "./ProductReview";
+
+const ProductTab = () => {
+  return (
+    <div>
+      <div>
+        <div>상품설명 탭</div>
+        <div>후기 탭</div>
+      </div>
+      <ProductDescription />
+      <ProductReview />
+    </div>
+  );
+};
+
+export default ProductTab;

--- a/itda-front/src/components/ProductDetail/ProductTab.tsx
+++ b/itda-front/src/components/ProductDetail/ProductTab.tsx
@@ -1,16 +1,19 @@
+import S from "./ProductDetailStyles";
 import ProductDescription from "./ProductDescription";
 import ProductReview from "./ProductReview";
 
 const ProductTab = () => {
   return (
-    <div>
-      <div>
-        <div>상품설명 탭</div>
-        <div>후기 탭</div>
-      </div>
+    <S.ProductTab.TabLayout>
+      <S.ProductTab.TabToggleLayer>
+        <S.ProductTab.InformationTabBlock>
+          상품설명
+        </S.ProductTab.InformationTabBlock>
+        <S.ProductTab.ReviewTabBlock>후기</S.ProductTab.ReviewTabBlock>
+      </S.ProductTab.TabToggleLayer>
       <ProductDescription />
       <ProductReview />
-    </div>
+    </S.ProductTab.TabLayout>
   );
 };
 

--- a/itda-front/src/router/Router.tsx
+++ b/itda-front/src/router/Router.tsx
@@ -10,21 +10,21 @@ import ThankYou from "components/ThankYou";
 import { Route, Switch, BrowserRouter } from "react-router-dom";
 
 const Router = () => {
-	return (
-		<BrowserRouter>
-			<Switch>
-				<Route exact path="/" component={Home}></Route>
-				<Route exact path="/login" component={Login}></Route>
-				<Route exact path="/myPage" component={MyPage}></Route>
-				<Route path="/products" component={Products}></Route>
-				<Route exact path="/products/:id" component={ProductDetail}></Route>
-				<Route exact path="/products/new" component={AddProduct}></Route>
-				<Route exact path="/cart" component={ShoppingCart}></Route>
-				<Route exact path="/signUp" component={SignUp}></Route>
-				<Route exact path="/thankYou" component={ThankYou}></Route>
-			</Switch>
-		</BrowserRouter>
-	);
+  return (
+    <BrowserRouter>
+      <Switch>
+        <Route exact path="/" component={Home}></Route>
+        <Route exact path="/login" component={Login}></Route>
+        <Route exact path="/myPage" component={MyPage}></Route>
+        <Route exact path="/products" component={Products}></Route>
+        <Route exact path="/products/:id" component={ProductDetail}></Route>
+        <Route exact path="/products/new" component={AddProduct}></Route>
+        <Route exact path="/cart" component={ShoppingCart}></Route>
+        <Route exact path="/signUp" component={SignUp}></Route>
+        <Route exact path="/thankYou" component={ThankYou}></Route>
+      </Switch>
+    </BrowserRouter>
+  );
 };
 
 export default Router;

--- a/itda-front/src/router/Router.tsx
+++ b/itda-front/src/router/Router.tsx
@@ -16,8 +16,8 @@ const Router = () => {
         <Route exact path="/" component={Home}></Route>
         <Route exact path="/login" component={Login}></Route>
         <Route exact path="/myPage" component={MyPage}></Route>
-        <Route exact path="/products" component={Products}></Route>
-        <Route exact path="/products/:id" component={ProductDetail}></Route>
+        <Route path="/products" component={Products}></Route>
+        <Route exact path="/product/:id" component={ProductDetail}></Route>
         <Route exact path="/products/new" component={AddProduct}></Route>
         <Route exact path="/cart" component={ShoppingCart}></Route>
         <Route exact path="/signUp" component={SignUp}></Route>

--- a/itda-front/src/stores/ProductDetailAtoms.ts
+++ b/itda-front/src/stores/ProductDetailAtoms.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const isTabStateDetailInfo = atom({
+  key: "isTabStateDetailInfo",
+  default: true,
+});

--- a/itda-front/src/stores/ProductDetailAtoms.ts
+++ b/itda-front/src/stores/ProductDetailAtoms.ts
@@ -4,3 +4,8 @@ export const isTabStateDetailInfo = atom({
   key: "isTabStateDetailInfo",
   default: true,
 });
+
+export const detailProductCount = atom({
+  key: "detailProductCount",
+  default: 0,
+});

--- a/itda-front/src/stores/ProductDetailAtoms.ts
+++ b/itda-front/src/stores/ProductDetailAtoms.ts
@@ -7,5 +7,5 @@ export const isTabStateDetailInfo = atom({
 
 export const detailProductCount = atom({
   key: "detailProductCount",
-  default: 0,
+  default: 1,
 });

--- a/itda-front/src/types/CommonTypes.ts
+++ b/itda-front/src/types/CommonTypes.ts
@@ -1,0 +1,6 @@
+export interface ICommonInfo {
+  id: number;
+  name: string;
+  imageUrl: string;
+  description: string;
+}

--- a/itda-front/src/types/ProductDetailTypes.ts
+++ b/itda-front/src/types/ProductDetailTypes.ts
@@ -1,0 +1,18 @@
+export interface IProductDetail extends ISeller {
+  price: number;
+  salesUnit: string;
+  weight: string;
+  deliveryFee: number;
+  deliveryFeeCondition: string;
+  origin: string;
+  packagingType: string;
+  detailDescription: string;
+  seller: ISeller;
+}
+
+export interface ISeller {
+  id: number;
+  name: string;
+  imageUrl: string;
+  description: string;
+}

--- a/itda-front/src/types/ProductDetailTypes.ts
+++ b/itda-front/src/types/ProductDetailTypes.ts
@@ -1,4 +1,6 @@
-export interface IProductDetail extends ISeller {
+import { ICommonInfo } from "./CommonTypes";
+
+export interface IProductDetail extends ICommonInfo {
   price: number;
   salesUnit: string;
   weight: string;
@@ -7,12 +9,5 @@ export interface IProductDetail extends ISeller {
   origin: string;
   packagingType: string;
   detailDescription: string;
-  seller: ISeller;
-}
-
-export interface ISeller {
-  id: number;
-  name: string;
-  imageUrl: string;
-  description: string;
+  seller: ICommonInfo;
 }


### PR DESCRIPTION
## 📌 개요
이슈번호 #38 
디테일 페이지 Product Information 컴포넌트 부분 세부 기능들 구현 및 스타일 지정

## 👩‍💻 작업 사항
- Product Page에 담길 큰 단위의 컴포넌트들 나누기
- Title, button, span 등 각 요소를 적재적소에 배치
- Styled-components로 대략적인 view 구성
- 수량 조절, tab toggle관련 atom 생성 및 로직 처리


## ✅ 참고 사항

- `types` 디렉토리 내에 `CommonTypes.ts` 파일을 만들었음
   - 주로 사용되는 타입들을 지정할 용도 (ex. `ICommonInfo` 참고)
- routing 설정 변경
   - 상품 페이지와 상품 상세페이지의 경로 겹침으로 인해 제대로 작동 X
   - `/products/:id` => `/product/:id` 로 수정 완료
