### PR TITLE
[FIX] category list style 수정

### DIFF
--- a/itda-front/src/components/Products/ProductsStyles.tsx
+++ b/itda-front/src/components/Products/ProductsStyles.tsx
@@ -117,6 +117,7 @@ const S = {
     `,
     ListLayout: styled.ul`
       position: absolute;
+      width: 12.5rem;
       top: 3.2rem;
       padding: 0;
       background-color: ${({ theme }) => theme.colors.white};


### PR DESCRIPTION
## 📌 개요

category list width 가 짧아서 텍스트가 2줄로 나와서 수정

## 👩‍💻 작업 사항

- width 고정 값으로 수정 

## ✅ 참고 사항

<img width="346" alt="스크린샷 2021-08-11 오후 2 35 03" src="https://user-images.githubusercontent.com/56783350/128974974-84dfa320-f851-4c03-931a-a28cbefa1499.png">

