### PR TITLE
[FIX] Home & BrandStory 페이지 스타일 수정(#69)

### DIFF
--- a/itda-front/src/components/BrandStory/BrandStoryStyles.tsx
+++ b/itda-front/src/components/BrandStory/BrandStoryStyles.tsx
@@ -3,22 +3,21 @@ import styled from "styled-components";
 const S = {
   BrandStory: {
     BrandStoryLayout: styled.section`
-      position: relative;
+      position: fixed;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
       height: 90vh;
-      min-width: 1600px;
+      width: 100%;
     `,
 
     Banner: styled.div`
       display: flex;
       justify-content: center;
-      position: absolute;
       width: 100%;
-      top: 25%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      height: 220px;
-      background-color: #f8f1f1;
-      font-size: ${({ theme }) => theme.fontSizes.largeTitleSize};
+      height: 200px;
+      background-color: ${({ theme }) => theme.colors.beige.light};
+      font-size: ${({ theme }) => theme.fontSizes.titleSize};
       font-family: "Gowun Batang", serif;
       font-weight: 900;
 
@@ -29,15 +28,13 @@ const S = {
     `,
 
     Layer: styled.div`
-      position: absolute;
       width: 45%;
-      top: 65%;
-      left: 50%;
-      transform: translate(-50%, -50%);
+      min-width: 700px;
     `,
 
     Title: styled.div`
       text-align: center;
+      color: ${({ theme }) => theme.colors.purple.dark};
       font-size: ${({ theme }) => theme.fontSizes.titleSize};
       font-family: "Gowun Batang", serif;
     `,

--- a/itda-front/src/components/Home/Hero.tsx
+++ b/itda-front/src/components/Home/Hero.tsx
@@ -3,11 +3,13 @@ import S from "./HomeStyles";
 const Hero = () => {
   return (
     <S.Hero.HeroLayout>
-      <S.Hero.Title>마음을 잇는 현명한 소비</S.Hero.Title>
-      <S.Hero.Slogan>
-        정직한 상품을 구매하고, 따뜻한 마음을 전달하세요
-      </S.Hero.Slogan>
-      <S.Hero.ProductsListButton>지금 보러가기</S.Hero.ProductsListButton>
+      <S.Hero.Layer>
+        <S.Hero.Title>마음을 잇는 현명한 소비</S.Hero.Title>
+        <S.Hero.Slogan>
+          정직한 상품을 구매하고, 따뜻한 마음을 전달하세요
+        </S.Hero.Slogan>
+        <S.Hero.ProductsListButton>지금 보러가기</S.Hero.ProductsListButton>
+      </S.Hero.Layer>
     </S.Hero.HeroLayout>
   );
 };

--- a/itda-front/src/components/Home/Home.tsx
+++ b/itda-front/src/components/Home/Home.tsx
@@ -1,6 +1,5 @@
 import Header from "components/common/Header/Header";
 import Hero from "./Hero";
-import BrandStory from "../BrandStory/BrandStory";
 import S from "./HomeStyles";
 
 const Home = () => {
@@ -10,7 +9,7 @@ const Home = () => {
         <Header />
         <Hero />
       </S.Home.HomeContainer>
-      <BrandStory />
+      {/* <BrandStory /> */}
     </>
   );
 };

--- a/itda-front/src/components/Home/HomeStyles.tsx
+++ b/itda-front/src/components/Home/HomeStyles.tsx
@@ -6,6 +6,7 @@ const S = {
     HomeContainer: styled.section`
       min-height: 90vh;
       width: 100vw;
+      min-width: 1000px;
       background-image: linear-gradient(
           rgba(0, 0, 0, 0.65),
           rgba(0, 0, 0, 0.503)
@@ -13,27 +14,35 @@ const S = {
         url(${backgroundImage});
       background-size: cover;
       background-position: center;
+      position: fixed;
     `,
   },
 
   Hero: {
     HeroLayout: styled.div`
+      position: relative;
       display: flex;
-      flex-direction: column;
-      justify-content: flex-start;
-      min-width: 1600px;
+      align-items: center;
+      height: 80%;
       font-family: "Gowun Dodum", serif;
-      margin-top: -8rem;
-      position: absolute;
-      width: 80%;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, 0%);
 
       & > * {
         margin: 1rem;
         color: white;
       }
+    `,
+
+    Layer: styled.div`
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, 50%);
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      width: 90%;
+      height: 220px;
+      padding: 0 2rem;
     `,
 
     Title: styled.div`


### PR DESCRIPTION
## 📌 개요

Resolve #69 
Home 페이지 Hero컴포넌트, BrandStory 페이지 비율 깨지지 않게 스타일 수정

## 👩‍💻 작업 사항

- [x] Home 페이지 타이틀 부분 잘리는 문제 수정 
- [x] BrandStory 페이지 전반적인 스타일 수정 (글씨 크기, 배너 사이즈 등) 

## ✅ 참고 사항

UI 스크린샷 - 맥북 13인치 100% 기준 
- Home 페이지
![image](https://user-images.githubusercontent.com/65105537/129193156-bb49822f-04f6-4114-b10e-6ef36c5cce03.png)

- BrandStory 페이지
![image](https://user-images.githubusercontent.com/65105537/129193316-30d9f021-bf62-411c-b18d-daf15eefb8a0.png)


