### PR TITLE
[Feat] 리뷰페이지, productDetail 기능 추가 및 수정사항 적용 완료

### DIFF
--- a/itda-front/src/components/ProductDetail/ProductDetail.tsx
+++ b/itda-front/src/components/ProductDetail/ProductDetail.tsx
@@ -2,6 +2,7 @@ import Header from "components/common/Header";
 import ProductInfo from "./ProductInfo";
 import ProductTab from "./ProductTab";
 import S from "./ProductDetailStyles";
+import TopButton from "components/common/TopButton";
 
 const ProductDetail = () => {
   return (
@@ -10,6 +11,7 @@ const ProductDetail = () => {
       <S.ProductDetailWall>
         <ProductInfo />
         <ProductTab />
+        <TopButton />
       </S.ProductDetailWall>
     </>
   );

--- a/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
+++ b/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
@@ -99,7 +99,7 @@ const S = {
     `,
     DetailBuyBlock: styled.div`
       display: flex;
-      justify-content: flex-end;
+      justify-content: space-between;
       align-items: flex-end;
       margin: 2.1rem 0 0 0;
       font-size: 0.8rem;

--- a/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
+++ b/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
@@ -109,7 +109,7 @@ const S = {
       display: flex;
       justify-content: space-between;
       align-items: flex-end;
-      width: 11.8rem;
+      width: 12.8rem;
     `,
 
     DetailTotalPrice: styled.span`

--- a/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
+++ b/itda-front/src/components/ProductDetail/ProductDetailStyles.ts
@@ -322,13 +322,15 @@ const S = {
     `,
     ReviewImageLayer: styled.div`
       display: flex;
-      width: 12rem;
+      width: 30rem;
       height: 8rem;
+
       margin: 1.5rem 0 0.5rem 0;
     `,
     ReviewImage: styled.img`
-      width: 100%;
-      height: 100%;
+      width: 190px;
+      height: 130px;
+      margin-right: 1rem;
     `,
     ReviewContentLayer: styled.div`
       margin-bottom: 1rem;

--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -19,6 +19,7 @@ const ProductInfo = () => {
     origin: "제주",
     packagingType: "냉장/종이포장",
     detailDescription: "###제목<br><p>내용들어가고 어쩌고</p>",
+    notice: "주의하세요",
     seller: {
       id: 1,
       name: "박크롱",
@@ -72,31 +73,30 @@ const ProductInfo = () => {
             </li>
             <li>
               <dl>
-                <dt>포장타입</dt>
+                <dt>포장 타입</dt>
                 <dd>{mockProduct.packagingType}</dd>
               </dl>
             </li>
             <li>
               <dl>
-                <dt>구매 수량</dt>
-                <dd>
-                  <S.ProductInfo.DetailCountDiv>
-                    <button
-                      disabled={productCount <= 1}
-                      onClick={() => setProductCount(productCount - 1)}
-                    >
-                      -
-                    </button>
-                    <div>{productCount}</div>
-                    <button onClick={() => setProductCount(productCount + 1)}>
-                      +
-                    </button>
-                  </S.ProductInfo.DetailCountDiv>
-                </dd>
+                <dt>안내 사항</dt>
+                <dd>{mockProduct.notice}</dd>
               </dl>
             </li>
           </S.ProductInfo.DetailProductInfo>
           <S.ProductInfo.DetailBuyBlock>
+            <S.ProductInfo.DetailCountDiv>
+              <button
+                disabled={productCount <= 1}
+                onClick={() => setProductCount(productCount - 1)}
+              >
+                -
+              </button>
+              <div>{productCount}</div>
+              <button onClick={() => setProductCount(productCount + 1)}>
+                +
+              </button>
+            </S.ProductInfo.DetailCountDiv>
             <S.ProductInfo.DetailPriceDiv>
               <span>총 상품 금액:</span>
               <S.ProductInfo.DetailTotalPrice>

--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -42,13 +42,13 @@ const ProductInfo = () => {
             {mockProduct.description}
           </S.ProductInfo.DetailShortInfo>
           <S.ProductInfo.DetailPrice>
-            {mockProduct.price}원
+            {mockProduct.price.toLocaleString()}원
           </S.ProductInfo.DetailPrice>
           <S.ProductInfo.DetailProductInfo>
             <li>
               <dl>
                 <dt>판매 단위</dt>
-                <dd>{mockProduct.salesUnit}</dd>
+                <dd>{mockProduct.salesUnit.toLocaleString()}</dd>
               </dl>
               <dl>
                 <dt>중량/용량</dt>
@@ -59,7 +59,7 @@ const ProductInfo = () => {
               <dl>
                 <dt>배송</dt>
                 <dd>
-                  {mockProduct.deliveryFee}원 (
+                  {mockProduct.deliveryFee.toLocaleString()}원 (
                   {mockProduct.deliveryFeeCondition})
                 </dd>
               </dl>
@@ -100,7 +100,7 @@ const ProductInfo = () => {
             <S.ProductInfo.DetailPriceDiv>
               <span>총 상품 금액:</span>
               <S.ProductInfo.DetailTotalPrice>
-                {mockProduct.price * productCount}원
+                {(mockProduct.price * productCount).toLocaleString()}원
               </S.ProductInfo.DetailTotalPrice>
             </S.ProductInfo.DetailPriceDiv>
           </S.ProductInfo.DetailBuyBlock>

--- a/itda-front/src/components/ProductDetail/ProductReview.tsx
+++ b/itda-front/src/components/ProductDetail/ProductReview.tsx
@@ -8,8 +8,11 @@ import {
   currentPage,
 } from "stores/ProductDetailAtoms";
 import PhotoModal from "./PhotoModal";
+import { reviewMock } from "./mocks";
+import { useEffect } from "react";
+import { IReview } from "types/ProductDetailTypes";
 
-const ProductReview = ({}) => {
+const ProductReview = () => {
   const [isPhotoReview, setIsPhotoReview] = useRecoilState(isReviewOnlyPhoto);
   const reviewTabRef = useRef(null);
 
@@ -17,30 +20,68 @@ const ProductReview = ({}) => {
   const [page, setPage] = useRecoilState(currentPage);
   const reviewsPerPage = 5;
 
+  useEffect(() => {
+    if (!isPhotoReview) {
+      // 포토리뷰가 아니면 그냥 전체 리뷰들 리스트 렌더링 해주면 됨
+      setProductReviews(
+        reviewMock.slice(
+          reviewsPerPage * (page - 1),
+          reviewsPerPage * (page - 1) + reviewsPerPage
+        )
+        // page가 atom으로 현재 default 1로 지정을 해둔 상태입니다. 0~5 5~10 의 인덱스 사이의 데이터 불러오는 로직입니다. 아직 서버를 달지 않아서 일단 이렇게나마 흉내내봤습니다.
+      );
+    } else {
+      setProductReviews(
+        //포토리뷰이면 포토리뷰만 필터링해서 렌더링
+        reviewMock
+          .filter((mock) => mock.image.length)
+          .slice(
+            reviewsPerPage * (page - 1),
+            reviewsPerPage * (page - 1) + reviewsPerPage
+          )
+        // page가 atom으로 현재 default 1로 지정을 해둔 상태입니다. 0~5 5~10 의 인덱스 사이의 데이터 불러오는 로직입니다. 아직 서버를 달지 않아서 일단 이렇게나마 흉내내봤습니다.
+      );
+    }
+  }, [page, isPhotoReview]);
+
   // 여기서 useEffect로 productReviews설정할 예정 (의존배열에 reviews가 들어갈듯합니다)
   // setCurrentPage를 Pagination 컴포넌트에 내려주고 있음
   // 그래서 currentPage가 변할때마다 ITDA api 설계글에 쓰여있는대로
   // Get api/products/1/reviews?pageNo=${currentPage}&offset=${reviewsPerPage}
   // 이렇게 할 예정입니다.
 
+  const getPhotoReviewOnly = () => {
+    setIsPhotoReview(true);
+    setPage(1);
+  };
+
+  const getTotalReview = () => {
+    setIsPhotoReview(false);
+    setPage(1);
+  };
+
   return (
     <S.ReviewTab.ReviewTabLayout ref={reviewTabRef}>
       <S.ReviewTab.ReviewTitleLayer>상품 후기</S.ReviewTab.ReviewTitleLayer>
       <S.ReviewTab.ReviewCountLayer>리뷰 13건</S.ReviewTab.ReviewCountLayer>
       <S.ReviewTab.ReviewPhotoTabLayer isPhoto={isPhotoReview}>
-        <div onClick={() => setIsPhotoReview(false)}>전체후기</div>
-        <div onClick={() => setIsPhotoReview(true)}>포토후기</div>
+        <div onClick={getTotalReview}>전체후기</div>
+        <div onClick={getPhotoReviewOnly}>포토후기</div>
       </S.ReviewTab.ReviewPhotoTabLayer>
       <S.ReviewTab.ReviewListLayer>
         <S.ReviewTab.ReviewListBlock>
-          {Array.from({ length: reviewsPerPage }).map((v) => (
-            <Review />
+          {productReviews.map((v) => (
+            <Review reviewData={v} />
           ))}
         </S.ReviewTab.ReviewListBlock>
         <Pagination
           reviewsPerPage={reviewsPerPage}
           paginate={setPage}
-          totalPosts={17}
+          totalPosts={
+            isPhotoReview
+              ? reviewMock.length
+              : reviewMock.filter((mock) => mock.image.length).length
+          }
           currentPage={page}
         />
       </S.ReviewTab.ReviewListLayer>
@@ -48,7 +89,7 @@ const ProductReview = ({}) => {
   );
 };
 
-const Review = () => {
+const Review = ({ reviewData }: { reviewData: IReview }) => {
   const [toggleState, setToggle] = useToggle(false);
 
   const handlePhotoClick = (e: React.MouseEvent<HTMLElement>) => {
@@ -63,20 +104,26 @@ const Review = () => {
         <S.ReviewTab.ReviewerLayer>
           <S.ReviewTab.ReviewerImageBlock src="https://ifh.cc/g/gFFnTG.jpg" />
           <div>
-            <S.ReviewTab.ReviewerNameBlock>크롱</S.ReviewTab.ReviewerNameBlock>
+            <S.ReviewTab.ReviewerNameBlock>
+              {reviewData.writer.name}
+            </S.ReviewTab.ReviewerNameBlock>
             <S.ReviewTab.ReviewDateBlock>
-              2021/06/06
+              {reviewData.date}
             </S.ReviewTab.ReviewDateBlock>
           </div>
         </S.ReviewTab.ReviewerLayer>
-        <S.ReviewTab.ReviewImageLayer>
-          <S.ReviewTab.ReviewImage
-            onClick={handlePhotoClick}
-            src="https://ifh.cc/g/gFFnTG.jpg"
-          />
-        </S.ReviewTab.ReviewImageLayer>
+        {reviewData.image.length !== 0 && (
+          <S.ReviewTab.ReviewImageLayer>
+            {reviewData.image.map((imgUrl) => (
+              <S.ReviewTab.ReviewImage
+                onClick={handlePhotoClick}
+                src={imgUrl}
+              />
+            ))}
+          </S.ReviewTab.ReviewImageLayer>
+        )}
         <S.ReviewTab.ReviewContentLayer>
-          상품이 너무 신선해요 ~ 추천합니다 ! 짱 추 !
+          {reviewData.contents}
         </S.ReviewTab.ReviewContentLayer>
       </S.ReviewTab.SingleReviewLayout>
       {toggleState && <PhotoModal handlePhotoClick={handlePhotoClick} />}

--- a/itda-front/src/components/ProductDetail/mocks.ts
+++ b/itda-front/src/components/ProductDetail/mocks.ts
@@ -1,0 +1,134 @@
+import { IReview } from "types/ProductDetailTypes";
+
+export const reviewMock: IReview[] = [
+  {
+    id: 1,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: [],
+    contents: "신선하고 맛있어요!",
+  },
+  {
+    id: 2,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: ["https://ifh.cc/g/gFFnTG.jpg"],
+    contents: "신선하고 맛있어요!78463234",
+  },
+  {
+    id: 3,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: ["https://ifh.cc/g/gFFnTG.jpg", "https://ifh.cc/g/gFFnTG.jpg"],
+    contents: "신선하고 맛있어요!444444444444444444",
+  },
+  {
+    id: 4,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: [],
+    contents: "신선하고 맛있어요!765765",
+  },
+  {
+    id: 5,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: [],
+    contents: "신선하고 맛있어요!7897",
+  },
+  {
+    id: 6,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: ["https://ifh.cc/g/gFFnTG.jpg", "https://ifh.cc/g/gFFnTG.jpg"],
+    contents: "신선하고 맛있어요1212121212!",
+  },
+  {
+    id: 7,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: ["https://ifh.cc/g/gFFnTG.jpg", "https://ifh.cc/g/gFFnTG.jpg"],
+    contents: "신선하고 맛있어요!23423423",
+  },
+  {
+    id: 8,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: ["https://ifh.cc/g/gFFnTG.jpg", "https://ifh.cc/g/gFFnTG.jpg"],
+    contents: "신선하고 맛있어요!",
+  },
+  {
+    id: 9,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: [],
+    contents: "신선하고 맛있어요22!",
+  },
+  {
+    id: 10,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: ["https://ifh.cc/g/gFFnTG.jpg", "https://ifh.cc/g/gFFnTG.jpg"],
+    contents: "신선하고 맛있어요333!",
+  },
+  {
+    id: 11,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: ["https://ifh.cc/g/gFFnTG.jpg", "https://ifh.cc/g/gFFnTG.jpg"],
+    contents: "신선하고 맛있어요4444!",
+  },
+  {
+    id: 12,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: [],
+    contents: "신선하고 맛있어요!",
+  },
+  {
+    id: 13,
+    writer: {
+      name: "cro**",
+      imgUrl: "https://ifh.cc/g/gFFnTG.jpg",
+    },
+    date: "2021-07-22",
+    image: [],
+    contents: "신선하고 맛있어요5555!",
+  },
+];

--- a/itda-front/src/components/common/ProductCard.tsx
+++ b/itda-front/src/components/common/ProductCard.tsx
@@ -1,7 +1,7 @@
 import S from "./CommonStyles";
 import useLazyLoad from "hooks/useLazyLoad";
 
-type ProductCardPropType = {
+type TProductCardPropType = {
   size: string;
   horizontal: boolean;
   productImg: string;
@@ -10,11 +10,11 @@ type ProductCardPropType = {
   seller: string;
 };
 
-type cardSizeType = {
-  [index: string]: widthHeightType;
+type TcardSizeType = {
+  [index: string]: TwidthHeightType;
 };
 
-type widthHeightType = {
+type TwidthHeightType = {
   width: number;
   height: number;
   fontSize: number;
@@ -27,7 +27,7 @@ const ProductCard = ({
   productName,
   productPrice,
   seller,
-}: ProductCardPropType) => {
+}: TProductCardPropType) => {
   return (
     <>
       {horizontal ? (
@@ -60,10 +60,10 @@ const VerticalCard = ({
   productName,
   productPrice,
   seller,
-}: ProductCardPropType) => {
+}: TProductCardPropType) => {
   const { imageSrc, imageRef } = useLazyLoad(productImg);
 
-  const verticalCardSize: cardSizeType = {
+  const verticalCardSize: TcardSizeType = {
     small: { width: 150, height: 200, fontSize: 13 },
     large: { width: 200, height: 250, fontSize: 15 },
     extra: { width: 350, height: 450, fontSize: 18 },
@@ -103,8 +103,8 @@ const HorizontalCard = ({
   productName,
   productPrice,
   seller,
-}: ProductCardPropType) => {
-  const horizontalCardSize: cardSizeType = {
+}: TProductCardPropType) => {
+  const horizontalCardSize: TcardSizeType = {
     small: { width: 200, height: 100, fontSize: 13 },
     large: { width: 250, height: 125, fontSize: 15 },
     extra: { width: 300, height: 400, fontSize: 16 },

--- a/itda-front/src/stores/ProductDetailAtoms.ts
+++ b/itda-front/src/stores/ProductDetailAtoms.ts
@@ -1,4 +1,5 @@
 import { atom } from "recoil";
+import { IReview } from "types/ProductDetailTypes";
 
 export const isTabStateDetailInfo = atom({
   key: "isTabStateDetailInfo",
@@ -15,7 +16,7 @@ export const isReviewOnlyPhoto = atom({
   default: false,
 });
 
-export const reviews = atom({
+export const reviews = atom<IReview[]>({
   key: "detailPageReviews",
   default: [],
 });

--- a/itda-front/src/types/CommonTypes.ts
+++ b/itda-front/src/types/CommonTypes.ts
@@ -4,3 +4,8 @@ export interface ICommonInfo {
   imageUrl: string;
   description: string;
 }
+
+export interface ICommonWriterInfo {
+  name: string;
+  imgUrl: string;
+}

--- a/itda-front/src/types/ProductDetailTypes.ts
+++ b/itda-front/src/types/ProductDetailTypes.ts
@@ -10,6 +10,7 @@ export interface IProductDetail extends ICommonInfo {
   packagingType: string;
   detailDescription: string;
   seller: ICommonInfo;
+  notice: string;
 }
 
 export interface IReview {

--- a/itda-front/src/types/ProductDetailTypes.ts
+++ b/itda-front/src/types/ProductDetailTypes.ts
@@ -1,4 +1,4 @@
-import { ICommonInfo } from "./CommonTypes";
+import { ICommonInfo, ICommonWriterInfo } from "./CommonTypes";
 
 export interface IProductDetail extends ICommonInfo {
   price: number;
@@ -10,4 +10,12 @@ export interface IProductDetail extends ICommonInfo {
   packagingType: string;
   detailDescription: string;
   seller: ICommonInfo;
+}
+
+export interface IReview {
+  id: number;
+  writer: ICommonWriterInfo;
+  date: string;
+  image: string[];
+  contents: string;
 }


### PR DESCRIPTION
## 📌 개요
리뷰페이지를 나중에 서버 요청 붙일시 어려움이 없도록 mockData로 테스트 겸 렌더링하기
안내사항에 대한 데이터도 서버에서 보내주기에 해당 칸 추가로 렌더링해줘야합니다.

## 👩‍💻 작업 사항

- mock data 만들어서 포토후기, 일반후기 필터링
- 가격에 쉼표 붙이기
- 안내사항(notice) 칸 넣어두기
- top button 붙여보기 (시간되면)

## ✅ 참고 사항

일단 돌아가도록 구현 해 두었고 대강 어떤 로직으로 필터링 할 지 고민해보았습니다. 
더 좋은 방법이 있으면 알려주세요.  주석으로 ProductReview쪽 코드 설명을 적어두었습니다.

구현한 사항들은 일단 정상적으로 작동합니당

