### PR TITLE
[FEAT] 장바구니 페이지 마크업, 스타일링, 재사용을 위한 Atoms 설계

### DIFF
--- a/itda-front/src/components/ShoppingCart/AddressInfo/AddressFormModal.tsx
+++ b/itda-front/src/components/ShoppingCart/AddressInfo/AddressFormModal.tsx
@@ -1,0 +1,6 @@
+import S from "../ShoppingCartStyles";
+const AddressFormModal = () => {
+  return <div></div>;
+};
+
+export default AddressFormModal;

--- a/itda-front/src/components/ShoppingCart/AddressInfo/AddressInfo.tsx
+++ b/itda-front/src/components/ShoppingCart/AddressInfo/AddressInfo.tsx
@@ -1,0 +1,14 @@
+import S from "../ShoppingCartStyles";
+import GradientButton from "components/common/Atoms/GradientButton";
+
+const AddressInfo = () => {
+  return (
+    <S.AddressInfo.Layout>
+      <S.AddressInfo.Title>배송지</S.AddressInfo.Title>
+      <S.AddressInfo.Contents>배송지를 입력해주세요. </S.AddressInfo.Contents>
+      <GradientButton width={"18rem"}>배송지 입력</GradientButton>
+    </S.AddressInfo.Layout>
+  );
+};
+
+export default AddressInfo;

--- a/itda-front/src/components/ShoppingCart/AddressInfo/index.ts
+++ b/itda-front/src/components/ShoppingCart/AddressInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddressInfo";

--- a/itda-front/src/components/ShoppingCart/PaymentInfo.tsx
+++ b/itda-front/src/components/ShoppingCart/PaymentInfo.tsx
@@ -1,0 +1,31 @@
+import S from "./ShoppingCartStyles";
+import GradientButton from "components/common/Atoms/GradientButton";
+
+const PaymentInfo = () => {
+  const subTitles = ["주문금액", "배송비", "합계"];
+  const subTitleList = subTitles.map((title, idx) => (
+    <li>
+      <S.PaymentInfo.SubTitle key={idx}>{title}</S.PaymentInfo.SubTitle>
+    </li>
+  ));
+  return (
+    <S.PaymentInfo.Layout>
+      <S.PaymentInfo.Title>결제 상세</S.PaymentInfo.Title>
+      <S.PaymentInfo.ContentsLayer>
+        <S.PaymentInfo.SubTitleBlock>
+          {subTitleList}
+        </S.PaymentInfo.SubTitleBlock>
+        <S.PaymentInfo.ContentsBlock>
+          <S.PaymentInfo.Contents>19,900원</S.PaymentInfo.Contents>
+          <S.PaymentInfo.Contents>3,000원</S.PaymentInfo.Contents>
+          <S.PaymentInfo.Contents>22,900원</S.PaymentInfo.Contents>
+        </S.PaymentInfo.ContentsBlock>
+      </S.PaymentInfo.ContentsLayer>
+      <GradientButton width={"18rem"} disabled={true}>
+        구매 하기
+      </GradientButton>
+    </S.PaymentInfo.Layout>
+  );
+};
+
+export default PaymentInfo;

--- a/itda-front/src/components/ShoppingCart/ShoppingCart.tsx
+++ b/itda-front/src/components/ShoppingCart/ShoppingCart.tsx
@@ -1,5 +1,45 @@
+import S from "./ShoppingCartStyles";
+import Header from "components/common/Header";
+import AddressInfo from "./AddressInfo/";
+import PaymentInfo from "./PaymentInfo";
+import ShoppingCartProduct from "./ShoppingCartProduct";
+import CheckButton from "components/common/Atoms/CheckButton";
 const ShoppingCart = () => {
-	return <div></div>;
+  return (
+    <>
+      <S.ShoppingCart.HeaderLayout>
+        <Header />
+      </S.ShoppingCart.HeaderLayout>
+
+      <S.ShoppingCart.CartHeaderLayout>
+        장바구니
+      </S.ShoppingCart.CartHeaderLayout>
+      <S.ShoppingCart.MainLayout>
+        <S.ShoppingCart.ContainerLayer>
+          <S.ShoppingCart.ProductsLayer>
+            <S.ShoppingCartProduct.HeaderLayout>
+              <CheckButton checked={false} />
+              <S.ShoppingCartProduct.HeaderTextLayer>
+                전체선택 (1개)
+              </S.ShoppingCartProduct.HeaderTextLayer>
+              <S.ShoppingCartProduct.HeaderTextLayer>
+                선택삭제
+              </S.ShoppingCartProduct.HeaderTextLayer>
+            </S.ShoppingCartProduct.HeaderLayout>
+            <ShoppingCartProduct />
+            <ShoppingCartProduct />
+            <ShoppingCartProduct />
+            <ShoppingCartProduct />
+          </S.ShoppingCart.ProductsLayer>
+          <S.ShoppingCart.SummaryLayer>
+            <AddressInfo />
+            <S.ShoppingCart.DivisionLine />
+            <PaymentInfo />
+          </S.ShoppingCart.SummaryLayer>
+        </S.ShoppingCart.ContainerLayer>
+      </S.ShoppingCart.MainLayout>
+    </>
+  );
 };
 
 export default ShoppingCart;

--- a/itda-front/src/components/ShoppingCart/ShoppingCartProduct.tsx
+++ b/itda-front/src/components/ShoppingCart/ShoppingCartProduct.tsx
@@ -1,0 +1,31 @@
+import S from "./ShoppingCartStyles";
+import CheckButton from "components/common/Atoms/CheckButton";
+import CounterButton from "components/common/Atoms/CounterButton";
+import CancelButton from "components/common/Atoms/CancelButton";
+import { useState } from "react";
+
+import useToggle from "hooks/useToggle";
+const ShoppingCartProduct = () => {
+  const [productCount, setProductCount] = useState(1);
+  const [isSelected, setIsSelected] = useToggle();
+
+  return (
+    <>
+      <S.ShoppingCartProduct.ContentsLayout>
+        <CheckButton checked={isSelected} onClick={setIsSelected} />
+        <S.ShoppingCartProduct.Image src="https://pbs.twimg.com/profile_images/1290662596367065090/9vCsXfMS_400x400.jpg" />
+        <S.ShoppingCartProduct.ProductNameLayer>
+          [루피] 상품명상품명상품명길면 밑으로 내려가요가요길어도 괜찮지만
+          하지만 2줄까지만 나오게... 하기
+        </S.ShoppingCartProduct.ProductNameLayer>
+        <CounterButton state={productCount} setState={setProductCount} />
+        <S.ShoppingCartProduct.ProductPrice>
+          10,000원
+        </S.ShoppingCartProduct.ProductPrice>
+        <CancelButton />
+      </S.ShoppingCartProduct.ContentsLayout>
+    </>
+  );
+};
+
+export default ShoppingCartProduct;

--- a/itda-front/src/components/ShoppingCart/ShoppingCartStyles.tsx
+++ b/itda-front/src/components/ShoppingCart/ShoppingCartStyles.tsx
@@ -30,7 +30,6 @@ const S = {
       grid-template-columns: 2fr 1fr;
       justify-items: center;
       width: 80rem;
-      /* outline: 1px blue solid; */
     `,
     ProductsLayer: styled.div`
       width: 100%;

--- a/itda-front/src/components/ShoppingCart/ShoppingCartStyles.tsx
+++ b/itda-front/src/components/ShoppingCart/ShoppingCartStyles.tsx
@@ -1,0 +1,133 @@
+import styled from "styled-components";
+import { GrDeliver } from "react-icons/gr";
+const S = {
+  ShoppingCart: {
+    CartHeaderLayout: styled.div`
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 6rem;
+      border: 1px solid ${({ theme }) => theme.colors.gray.extraLight};
+      background: ${({ theme }) => theme.colors.white};
+      box-shadow: 0px 1px 1px 0px ${({ theme }) => theme.colors.gray.extraLight};
+      backdrop-filter: blur(4px);
+      font-weight: bold;
+      font-size: 1.7rem;
+    `,
+    HeaderLayout: styled.div`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      backdrop-filter: blur(4px);
+    `,
+
+    MainLayout: styled.div`
+      display: flex;
+      justify-content: center;
+    `,
+    ContainerLayer: styled.div`
+      display: grid;
+      grid-template-columns: 2fr 1fr;
+      justify-items: center;
+      width: 80rem;
+      /* outline: 1px blue solid; */
+    `,
+    ProductsLayer: styled.div`
+      width: 100%;
+    `,
+    SummaryLayer: styled.div`
+      border-left: 1px solid ${({ theme }) => theme.colors.gray.light};
+      padding: 1rem 2rem;
+    `,
+    DivisionLine: styled.div`
+      width: 100%;
+      border-bottom: 2px dashed ${({ theme }) => theme.colors.gray.light};
+    `,
+  },
+  AddressInfo: {
+    Layout: styled.div`
+      padding: 2rem 0;
+    `,
+    Title: styled.div`
+      font-size: 1.3rem;
+      font-weight: bold;
+      padding-bottom: 1rem;
+    `,
+    Contents: styled.div`
+      padding-bottom: 2rem;
+    `,
+  },
+  ShoppingCartProduct: {
+    HeaderLayout: styled.div`
+      display: flex;
+      align-items: center;
+      padding: 1rem;
+    `,
+    HeaderTextLayer: styled.div`
+      display: flex;
+      align-items: center;
+      padding-left: 0.5rem;
+      font-weight: bold;
+    `,
+    ContentsLayout: styled.div`
+      display: flex;
+      align-items: center;
+      width: 100%;
+      border-top: 1px solid ${({ theme }) => theme.colors.gray.light};
+      padding: 2rem;
+    `,
+    Image: styled.img`
+      width: 100px;
+      margin-left: 20px;
+    `,
+    ProductNameLayer: styled.div`
+      width: 24rem;
+      font-weight: bold;
+      padding: 0 2rem;
+      margin-right: 1rem;
+    `,
+    ProductPrice: styled.span`
+      text-align: right;
+      padding-right: 2rem;
+      width: 10rem;
+      font-weight: bold;
+    `,
+    SelectOption: styled.span``,
+  },
+
+  AddressFormModal: {},
+  PaymentInfo: {
+    Layout: styled.div`
+      padding: 2rem 0;
+    `,
+    Title: styled.div`
+      font-size: 1.3rem;
+      font-weight: bold;
+      padding-bottom: 1rem;
+    `,
+    SubTitle: styled.div`
+      font-weight: bold;
+      padding-bottom: 1rem;
+    `,
+    SubTitleBlock: styled.ul``,
+    ContentsBlock: styled.div``,
+    ContentsLayer: styled.div`
+      display: flex;
+      justify-content: space-between;
+      padding: 0 0.3rem;
+    `,
+    Contents: styled.div`
+      text-align: right;
+      padding-bottom: 1rem;
+    `,
+    Button: styled.button`
+      color: white;
+      background-color: ${({ theme }) => theme.colors.mint.normal};
+      height: 4rem;
+      width: 18rem;
+      border-radius: 0.4rem;
+    `,
+  },
+};
+
+export default S;

--- a/itda-front/src/components/common/Atoms/AtomsStyles.tsx
+++ b/itda-front/src/components/common/Atoms/AtomsStyles.tsx
@@ -1,0 +1,68 @@
+import styled from "styled-components";
+import {
+  IoIosCheckmarkCircle,
+  IoIosCheckmarkCircleOutline,
+} from "react-icons/io";
+import { HiX, HiOutlineMinusSm, HiOutlinePlusSm } from "react-icons/hi";
+import { FaPlus, FaMinus } from "react-icons/fa";
+const S = {
+  CounterButton: {
+    Layout: styled.div`
+      display: flex;
+      width: 5.5rem;
+      height: 2rem;
+      border: 1px solid #dddfe1;
+      border-radius: 4px;
+      div {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 3rem;
+        font-size: 15px;
+      }
+      button {
+        /* outline: red 1px solid; */
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 2rem;
+
+        background: none;
+        font-weight: bold;
+      }
+    `,
+    MinusIcon: styled(FaMinus)`
+      width: 10px;
+      color: ${({ theme }) => theme.colors.gray.dark};
+    `,
+    PlusIcon: styled(FaPlus)`
+      width: 10px;
+      color: ${({ theme }) => theme.colors.gray.dark};
+    `,
+  },
+  CheckButton: {
+    Checked: styled(IoIosCheckmarkCircle)`
+      color: ${({ theme }) => theme.colors.navy.normal};
+      width: 1.7rem;
+      height: 1.7rem;
+      cursor: pointer;
+    `,
+    Unchecked: styled(IoIosCheckmarkCircleOutline)`
+      color: ${({ theme }) => theme.colors.navy.normal};
+      width: 1.7rem;
+      height: 1.7rem;
+      cursor: pointer;
+    `,
+  },
+  CancelButton: {
+    Icon: styled(HiX)`
+      color: ${({ theme }) => theme.colors.gray.light};
+      cursor: pointer;
+      :hover {
+        color: ${({ theme }) => theme.colors.navy.normal};
+      }
+    `,
+  },
+};
+
+export default S;

--- a/itda-front/src/components/common/Atoms/AtomsStyles.tsx
+++ b/itda-front/src/components/common/Atoms/AtomsStyles.tsx
@@ -3,7 +3,7 @@ import {
   IoIosCheckmarkCircle,
   IoIosCheckmarkCircleOutline,
 } from "react-icons/io";
-import { HiX, HiOutlineMinusSm, HiOutlinePlusSm } from "react-icons/hi";
+import { HiX } from "react-icons/hi";
 import { FaPlus, FaMinus } from "react-icons/fa";
 const S = {
   CounterButton: {
@@ -21,7 +21,6 @@ const S = {
         font-size: 15px;
       }
       button {
-        /* outline: red 1px solid; */
         display: flex;
         justify-content: center;
         align-items: center;

--- a/itda-front/src/components/common/Atoms/CancelButton.tsx
+++ b/itda-front/src/components/common/Atoms/CancelButton.tsx
@@ -1,0 +1,11 @@
+import S from "./AtomsStyles";
+
+type TCheckButton = {
+  onClick?: React.MouseEventHandler<SVGElement>;
+};
+
+const CancelButton = ({ onClick }: TCheckButton) => {
+  return <S.CancelButton.Icon onClick={onClick} />;
+};
+
+export default CancelButton;

--- a/itda-front/src/components/common/Atoms/CheckButton.tsx
+++ b/itda-front/src/components/common/Atoms/CheckButton.tsx
@@ -1,0 +1,14 @@
+import S from "./AtomsStyles";
+type TCheckButton = {
+  checked: boolean;
+  onClick?: React.MouseEventHandler<SVGElement>;
+};
+const CheckButton = ({ checked = false, onClick }: TCheckButton) => {
+  return checked ? (
+    <S.CheckButton.Checked onClick={onClick} />
+  ) : (
+    <S.CheckButton.Unchecked onClick={onClick} />
+  );
+};
+
+export default CheckButton;

--- a/itda-front/src/components/common/Atoms/CounterButton.tsx
+++ b/itda-front/src/components/common/Atoms/CounterButton.tsx
@@ -1,0 +1,22 @@
+import S from "./AtomsStyles";
+
+type TCounter = {
+  state: number;
+  setState: React.Dispatch<React.SetStateAction<number>>;
+};
+
+const CounterButton = ({ state, setState }: TCounter) => {
+  return (
+    <S.CounterButton.Layout>
+      <button disabled={state <= 1} onClick={() => setState(state - 1)}>
+        <S.CounterButton.MinusIcon />
+      </button>
+      <div>{state}</div>
+      <button onClick={() => setState(state + 1)}>
+        <S.CounterButton.PlusIcon />
+      </button>
+    </S.CounterButton.Layout>
+  );
+};
+
+export default CounterButton;

--- a/itda-front/src/components/common/Atoms/GradientButton.tsx
+++ b/itda-front/src/components/common/Atoms/GradientButton.tsx
@@ -1,0 +1,38 @@
+import { withStyles } from "@material-ui/core/styles";
+import Button from "@material-ui/core/Button";
+
+type TGradientButton = {
+  width: string;
+  children: React.ReactChild;
+  disabled?: boolean;
+  onClick?: React.MouseEventHandler<HTMLElement>;
+};
+
+const GradientButton = ({
+  width,
+  children,
+  onClick,
+  disabled = false,
+}: TGradientButton) => {
+  const StyledButton = withStyles({
+    root: {
+      background: `${
+        disabled ? "#cecece" : "linear-gradient(45deg, #3D84A8 30%,#16C79A 90%)"
+      }`,
+      borderRadius: 3,
+      border: 0,
+      color: "white",
+      height: 48,
+      width: width,
+      boxShadow: "0 3px 5px 2px #cecece",
+      fontSize: "18px",
+      fontWeight: "bold",
+    },
+    label: {
+      textTransform: "capitalize",
+    },
+  })(Button);
+  return <StyledButton onClick={onClick}>{children}</StyledButton>;
+};
+
+export default GradientButton;

--- a/itda-front/src/stores/ShoppingCartProductAtoms.ts
+++ b/itda-front/src/stores/ShoppingCartProductAtoms.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const isProductSelected = atom({
+  key: "isProductSelected",
+  default: false,
+});


### PR DESCRIPTION
## 📌 개요
장바구니 페이지 view 구현을 진행하며 Atoms를 추가했습니다.

## 👩‍💻 작업 사항
- 장바구니 페이지 view 구현 완료
-  Atoms를 컴포넌트 구현

작업한 내용을 적어주세요.

## ✅ 참고 사항
- @wjddnjswjd12 참고로 제니가 상품 디테일 페이지에서 구현하셨던 counter버튼도 Atoms 내 CounterButton 으로 구현해놔서 기존 코드 지우시고 CounterButton 그대로 가져다 쓰시면 됩니다!! ( 텍스트로 작성되어 있었던 + , -는 리액트 아이콘으로 대체 된 점 참고 바랍니다~!🙂)  
- Atom의 경우 재사용성을 높이기 위하여 필요하신 props이 있다면 자유롭게 업데이트 하셔도 됩니다! (업데이트시 공유 부탁드려요!)
- 장바구니 페이지내 제품명의 경우 2줄 이상 나올 경우 예전에 제니가 적용하셨던 ... <- 이걸 적용하면 좋을 것 같습니다 (아직은 적용 안 함ㅎㅎ)

<img width="1436" alt="스크린샷 2021-08-14 오전 3 16 41" src="https://user-images.githubusercontent.com/56783350/129402146-d6312482-0d8a-4b82-9a60-474c73ffae5c.png">