### PR TITLE
[FIX] SideDrawer 닫힐 때 애니메이션 에러 해결 (#84)

### DIFF
--- a/itda-front/src/components/common/CommonStyles.tsx
+++ b/itda-front/src/components/common/CommonStyles.tsx
@@ -11,26 +11,30 @@ import { VscChromeClose } from "react-icons/vsc";
 import { HiChevronDoubleUp } from "react-icons/hi";
 import Button from "@material-ui/core/Button";
 
-const slideIn = keyframes`
-from {
-  transform: translateX(100%)
-}
-to {
-  transform: translateX(0%)
-}
+const slideIn = css`
+  @keyframes slideIn {
+    from {
+      transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0%);
+    }
+  }
 `;
 
-const slideOut = keyframes`
-  from {
-    transform: translateX(0%)
-  }
-  to {
-    transform: translateX(100%)
+const slideOut = css`
+  @keyframes slideOut {
+    from {
+      transform: translateX(0%);
+    }
+    to {
+      transform: translateX(100%);
+    }
   }
 `;
 
 interface ICloseButton {
-  isClicked: boolean;
+  isClicked: undefined | boolean;
 }
 
 const S = {
@@ -211,7 +215,7 @@ const S = {
   },
 
   SideDrawer: {
-    DrawerLayout: styled.div`
+    DrawerLayout: styled.div<{ isClicked: undefined | boolean }>`
       background-color: #f2f6f8;
       height: 100vh;
       width: 430px;
@@ -221,9 +225,42 @@ const S = {
       z-index: 99;
       padding: 1rem;
 
-      animation-duration: 0.5s;
-      animation-timing-function: easeOutSine;
-      animation-name: ${(isClicked) => (isClicked ? slideIn : slideOut)};
+      @keyframes slideIn {
+        from {
+          transform: translateX(100%);
+        }
+        to {
+          transform: translateX(0%);
+        }
+      }
+
+      @keyframes slideOut {
+        from {
+          transform: translateX(0%);
+        }
+        to {
+          transform: translateX(100%);
+        }
+      }
+
+      ${({ isClicked }) => {
+        return isClicked === undefined
+          ? css`
+              transform: translateX(100%);
+            `
+          : css`
+              animation-fill-mode: forwards;
+              animation-duration: 0.5s;
+              animation-timing-function: easeOutSine;
+              animation-name: ${({
+                isClicked,
+              }: {
+                isClicked: undefined | boolean;
+              }) => {
+                return isClicked ? "slideIn" : "slideOut";
+              }};
+            `;
+      }}
     `,
 
     DrawerHeaderLayer: styled.div`
@@ -242,13 +279,13 @@ const S = {
         cursor: pointer;
       }
       /* 장바구니가 옆으로 사라지게 하는 애니메이션인데 현재는 작동이 안됌. 임시보류 */
-      ${(isClicked) =>
+      /* ${(isClicked) =>
         isClicked &&
         css`
           animation-name: ${slideOut};
           animation-duration: 0.4s;
           animation-timing-function: ease;
-        `}
+        `} */
     `,
 
     DrawerCloseIcon: styled(VscChromeClose)`

--- a/itda-front/src/components/common/CommonStyles.tsx
+++ b/itda-front/src/components/common/CommonStyles.tsx
@@ -11,28 +11,6 @@ import { VscChromeClose } from "react-icons/vsc";
 import { HiChevronDoubleUp } from "react-icons/hi";
 import Button from "@material-ui/core/Button";
 
-const slideIn = css`
-  @keyframes slideIn {
-    from {
-      transform: translateX(100%);
-    }
-    to {
-      transform: translateX(0%);
-    }
-  }
-`;
-
-const slideOut = css`
-  @keyframes slideOut {
-    from {
-      transform: translateX(0%);
-    }
-    to {
-      transform: translateX(100%);
-    }
-  }
-`;
-
 interface ICloseButton {
   isClicked: undefined | boolean;
 }
@@ -278,14 +256,6 @@ const S = {
         color: #acacac;
         cursor: pointer;
       }
-      /* 장바구니가 옆으로 사라지게 하는 애니메이션인데 현재는 작동이 안됌. 임시보류 */
-      /* ${(isClicked) =>
-        isClicked &&
-        css`
-          animation-name: ${slideOut};
-          animation-duration: 0.4s;
-          animation-timing-function: ease;
-        `} */
     `,
 
     DrawerCloseIcon: styled(VscChromeClose)`

--- a/itda-front/src/components/common/Header/Header.tsx
+++ b/itda-front/src/components/common/Header/Header.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-// import useToggle from "hooks/useToggle";
 
 import S from "../CommonStyles";
 import SideDrawer from "./SideDrawer";
@@ -18,7 +17,6 @@ const Header = () => {
   const color = isHomePage ? "#ffffff" : "#555555";
 
   const toggleSideDrawer = () => {
-    console.log("toggle 장바구니", isClicked);
     setIsClicked(true);
   };
 

--- a/itda-front/src/components/common/Header/Header.tsx
+++ b/itda-front/src/components/common/Header/Header.tsx
@@ -1,11 +1,13 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import useToggle from "hooks/useToggle";
+// import useToggle from "hooks/useToggle";
+
 import S from "../CommonStyles";
 import SideDrawer from "./SideDrawer";
 import useScrollToggle from "hooks/useScrollToggle";
 
 const Header = () => {
-  const [isClicked, setIsClicked] = useToggle(false);
+  const [isClicked, setIsClicked] = useState<undefined | boolean>(undefined);
   const scrollFlag = useScrollToggle(false);
 
   const checkPageName = () => {
@@ -15,7 +17,10 @@ const Header = () => {
   const isHomePage = checkPageName();
   const color = isHomePage ? "#ffffff" : "#555555";
 
-  const toggleSideDrawer = () => setIsClicked(true);
+  const toggleSideDrawer = () => {
+    console.log("toggle 장바구니", isClicked);
+    setIsClicked(true);
+  };
 
   return scrollFlag ? (
     <></>
@@ -41,9 +46,7 @@ const Header = () => {
           <S.Header.LoginButton color={color} />
         </S.Header.RightBlock>
       </S.Header.HeaderLayer>
-      {isClicked && (
-        <SideDrawer isClicked={isClicked} setIsClicked={setIsClicked} />
-      )}
+      <SideDrawer isClicked={isClicked} setIsClicked={setIsClicked} />
     </S.Header.HeaderLayout>
   );
 };

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -2,18 +2,17 @@ import S from "../CommonStyles";
 import ProductCard from "../ProductCard";
 
 type TSideDrawer = {
-  isClicked: boolean;
+  isClicked: undefined | boolean;
   setIsClicked: (value: boolean) => void;
 };
 
 const SideDrawer = ({ isClicked, setIsClicked }: TSideDrawer) => {
-  console.log(isClicked);
   const handleCloseButtonClick = () => {
     setIsClicked(false);
   };
 
   return (
-    <S.SideDrawer.DrawerLayout>
+    <S.SideDrawer.DrawerLayout isClicked={isClicked}>
       <S.SideDrawer.DrawerHeaderLayer>
         <div>담은 상품 목록</div>
         <S.SideDrawer.DrawerCardCloseButton


### PR DESCRIPTION
## 📌 개요

Resolve #84 
장바구니 (SideDrawer) 닫힐 때 애니메이션 적용 안되는 에러 해결

## 👩‍💻 작업 사항

- [x] 장바구니 닫힐 때 애니메이션 적용되지 않는 버그 해결

## ✅ 참고 사항
- 초기값을 undefined로 줘야하는 문제때문에 useToggle -> useState 사용으로 다시 정정
- UI gif
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/65105537/129457712-4e14a846-4979-4014-b797-01709233c736.gif)
