### PR TITLE
[FEAT] shopping cart페이지의 select 기능 구현

### DIFF
--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -1,4 +1,4 @@
-import CounterButton from "components/common/Atoms/CounterButton";
+import StepperButton from "components/common/Atoms/StepperButton";
 import { useRecoilState } from "recoil";
 import { detailProductCount } from "stores/ProductDetailAtoms";
 import { IProductDetail } from "types/ProductDetailTypes";
@@ -91,7 +91,7 @@ const ProductInfo = ({ match }: RouteComponentProps<MatchParams>) => {
             </li>
           </S.ProductInfo.DetailProductInfo>
           <S.ProductInfo.DetailBuyBlock>
-            <CounterButton state={productCount} setState={setProductCount} />
+            <StepperButton state={productCount} setState={setProductCount} />
             <S.ProductInfo.DetailPriceDiv>
               <span>총 상품 금액:</span>
               <S.ProductInfo.DetailTotalPrice>

--- a/itda-front/src/components/ShoppingCart/PaymentInfo.tsx
+++ b/itda-front/src/components/ShoppingCart/PaymentInfo.tsx
@@ -4,7 +4,7 @@ import GradientButton from "components/common/Atoms/GradientButton";
 const PaymentInfo = () => {
   const subTitles = ["주문금액", "배송비", "합계"];
   const subTitleList = subTitles.map((title, idx) => (
-    <li>
+    <li key={idx}>
       <S.PaymentInfo.SubTitle key={idx}>{title}</S.PaymentInfo.SubTitle>
     </li>
   ));

--- a/itda-front/src/components/ShoppingCart/ShoppingCart.tsx
+++ b/itda-front/src/components/ShoppingCart/ShoppingCart.tsx
@@ -4,7 +4,79 @@ import AddressInfo from "./AddressInfo/";
 import PaymentInfo from "./PaymentInfo";
 import ShoppingCartProduct from "./ShoppingCartProduct";
 import CheckButton from "components/common/Atoms/CheckButton";
+import { selectedProduct, cartProductData } from "stores/ShoppingCartAtoms";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { useEffect, useState } from "react";
+import { GETCartData } from "util/mock/GETCartData";
+
 const ShoppingCart = () => {
+  const [isAllSelected, setIsAllSelected] = useState(false);
+  const [cartProductState, setCartProductState] = useRecoilState(
+    cartProductData
+  );
+  const [selectedProductState, setSelectedProductState] = useRecoilState(
+    selectedProduct
+  );
+
+  const handleCheckButton = () => {
+    if (selectedProductState.size < cartProductState.length) {
+      cartProductState.forEach(x => {
+        if (!selectedProductState.has(x.id)) {
+          const { id, imageUrl, productName, price, count } = x;
+          setSelectedProductState(
+            prev =>
+              new Map([
+                ...prev,
+                [
+                  id,
+                  {
+                    id,
+                    imageUrl,
+                    productName,
+                    price,
+                    count,
+                  },
+                ],
+              ])
+          );
+        }
+      });
+      setIsAllSelected(false);
+
+      //전체 선택 눌러서 나머지 아이템 다 선택
+    } else {
+      //전체 선택 해제
+      setIsAllSelected(false);
+      setSelectedProductState(prev => new Map());
+    }
+  };
+
+  const cartProductList = () => {
+    return cartProductState.map(product => (
+      <ShoppingCartProduct
+        key={product.id}
+        id={product.id}
+        imageUrl={product.imageUrl}
+        productName={product.productName}
+        price={product.price}
+        count={product.count}
+      />
+    ));
+  };
+
+  useEffect(() => {
+    //TODO: API : GET CART
+    const { data } = GETCartData;
+    const { detail } = data;
+    setCartProductState(detail);
+  }, []);
+
+  useEffect(() => {
+    if (selectedProductState.size === cartProductState.length)
+      setIsAllSelected(true);
+    else setIsAllSelected(false);
+  }, [selectedProductState]);
+
   return (
     <>
       <S.ShoppingCart.HeaderLayout>
@@ -18,18 +90,18 @@ const ShoppingCart = () => {
         <S.ShoppingCart.ContainerLayer>
           <S.ShoppingCart.ProductsLayer>
             <S.ShoppingCartProduct.HeaderLayout>
-              <CheckButton checked={false} />
+              <CheckButton
+                checked={isAllSelected}
+                onClick={handleCheckButton}
+              />
               <S.ShoppingCartProduct.HeaderTextLayer>
-                전체선택 (1개)
+                전체선택 ({selectedProductState.size}개)
               </S.ShoppingCartProduct.HeaderTextLayer>
               <S.ShoppingCartProduct.HeaderTextLayer>
                 선택삭제
               </S.ShoppingCartProduct.HeaderTextLayer>
             </S.ShoppingCartProduct.HeaderLayout>
-            <ShoppingCartProduct />
-            <ShoppingCartProduct />
-            <ShoppingCartProduct />
-            <ShoppingCartProduct />
+            {cartProductList()}
           </S.ShoppingCart.ProductsLayer>
           <S.ShoppingCart.SummaryLayer>
             <AddressInfo />

--- a/itda-front/src/components/ShoppingCart/ShoppingCartProduct.tsx
+++ b/itda-front/src/components/ShoppingCart/ShoppingCartProduct.tsx
@@ -1,26 +1,66 @@
+import { useState, useEffect } from "react";
 import S from "./ShoppingCartStyles";
 import CheckButton from "components/common/Atoms/CheckButton";
-import CounterButton from "components/common/Atoms/CounterButton";
+import StepperButton from "components/common/Atoms/StepperButton";
 import CancelButton from "components/common/Atoms/CancelButton";
-import { useState } from "react";
+import { selectedProduct } from "stores/ShoppingCartAtoms";
+import { useRecoilState } from "recoil";
+import { IShoppingCartProduct } from "types/ShoppingCartTypes";
 
-import useToggle from "hooks/useToggle";
-const ShoppingCartProduct = () => {
-  const [productCount, setProductCount] = useState(1);
-  const [isSelected, setIsSelected] = useToggle();
+const ShoppingCartProduct = ({
+  id,
+  imageUrl,
+  productName,
+  price,
+  count,
+}: IShoppingCartProduct) => {
+  const [selectedProductState, setSelectedProductState] = useRecoilState(
+    selectedProduct
+  );
+  useEffect(() => {
+    selectedProductState.has(id) ? setIsSelected(true) : setIsSelected(false);
+  }, [selectedProductState]);
+
+  const [productCount, setProductCount] = useState(count);
+  const [isSelected, setIsSelected] = useState(false);
+  const handleCheckButton = () => {
+    if (!isSelected) {
+      setSelectedProductState(
+        prev =>
+          new Map([
+            ...prev,
+            [
+              id,
+              {
+                id,
+                imageUrl,
+                productName,
+                price,
+                count,
+              },
+            ],
+          ])
+      );
+    } else {
+      setSelectedProductState(prev => {
+        const newState = new Map(prev);
+        newState.delete(id);
+        return newState;
+      });
+    }
+  };
 
   return (
     <>
       <S.ShoppingCartProduct.ContentsLayout>
-        <CheckButton checked={isSelected} onClick={setIsSelected} />
-        <S.ShoppingCartProduct.Image src="https://pbs.twimg.com/profile_images/1290662596367065090/9vCsXfMS_400x400.jpg" />
+        <CheckButton checked={isSelected} onClick={handleCheckButton} />
+        <S.ShoppingCartProduct.Image src={imageUrl} />
         <S.ShoppingCartProduct.ProductNameLayer>
-          [루피] 상품명상품명상품명길면 밑으로 내려가요가요길어도 괜찮지만
-          하지만 2줄까지만 나오게... 하기
+          {productName}
         </S.ShoppingCartProduct.ProductNameLayer>
-        <CounterButton state={productCount} setState={setProductCount} />
+        <StepperButton state={productCount} setState={setProductCount} />
         <S.ShoppingCartProduct.ProductPrice>
-          10,000원
+          {(productCount * price).toLocaleString()}
         </S.ShoppingCartProduct.ProductPrice>
         <CancelButton />
       </S.ShoppingCartProduct.ContentsLayout>

--- a/itda-front/src/components/ShoppingCart/ShoppingCartService.tsx
+++ b/itda-front/src/components/ShoppingCart/ShoppingCartService.tsx
@@ -1,0 +1,5 @@
+const ShoppingCartService = () => {
+  return <div></div>;
+};
+
+export default ShoppingCartService;

--- a/itda-front/src/components/common/Atoms/AtomsStyles.tsx
+++ b/itda-front/src/components/common/Atoms/AtomsStyles.tsx
@@ -7,7 +7,7 @@ import { HiX } from "react-icons/hi";
 import { FaPlus, FaMinus } from "react-icons/fa";
 import Button from "@material-ui/core/Button";
 const S = {
-  CounterButton: {
+  StepperButton: {
     Layout: styled.div`
       display: flex;
       width: 5.5rem;

--- a/itda-front/src/components/common/Atoms/StepperButton.tsx
+++ b/itda-front/src/components/common/Atoms/StepperButton.tsx
@@ -5,18 +5,18 @@ type TCounter = {
   setState: React.Dispatch<React.SetStateAction<number>>;
 };
 
-const CounterButton = ({ state, setState }: TCounter) => {
+const StepperButton = ({ state, setState }: TCounter) => {
   return (
-    <S.CounterButton.Layout>
+    <S.StepperButton.Layout>
       <button disabled={state <= 1} onClick={() => setState(state - 1)}>
-        <S.CounterButton.MinusIcon />
+        <S.StepperButton.MinusIcon />
       </button>
       <div>{state}</div>
       <button onClick={() => setState(state + 1)}>
-        <S.CounterButton.PlusIcon />
+        <S.StepperButton.PlusIcon />
       </button>
-    </S.CounterButton.Layout>
+    </S.StepperButton.Layout>
   );
 };
 
-export default CounterButton;
+export default StepperButton;

--- a/itda-front/src/stores/ShoppingCartAtoms.ts
+++ b/itda-front/src/stores/ShoppingCartAtoms.ts
@@ -1,0 +1,12 @@
+import { atom, selector } from "recoil";
+import { IShoppingCartProduct } from "types/ShoppingCartTypes";
+
+export const selectedProduct = atom({
+  key: "selectedProduct",
+  default: new Map<number, IShoppingCartProduct>(),
+});
+
+export const cartProductData = atom<IShoppingCartProduct[]>({
+  key: "cartProductData",
+  default: [],
+});

--- a/itda-front/src/stores/ShoppingCartProductAtoms.ts
+++ b/itda-front/src/stores/ShoppingCartProductAtoms.ts
@@ -1,6 +1,0 @@
-import { atom } from "recoil";
-
-export const isProductSelected = atom({
-  key: "isProductSelected",
-  default: false,
-});

--- a/itda-front/src/types/ShoppingCartTypes.ts
+++ b/itda-front/src/types/ShoppingCartTypes.ts
@@ -1,0 +1,9 @@
+interface IShoppingCartProduct {
+  id: number;
+  imageUrl: string;
+  productName: string;
+  price: number;
+  count: number;
+}
+
+export type { IShoppingCartProduct };

--- a/itda-front/src/util/mock/GETCartData.ts
+++ b/itda-front/src/util/mock/GETCartData.ts
@@ -1,0 +1,23 @@
+export const GETCartData = {
+  success: true,
+  data: {
+    defaultAddress: "서울특별시 강남구 역삼동",
+    detail: [
+      {
+        id: 1,
+        imageUrl: "https://i.ndtvimg.com/mt/cooks/2014-11/carrots.jpg",
+        productName: "제품 이름",
+        price: 50000,
+        count: 2,
+      },
+      {
+        id: 2,
+        imageUrl: "https://i.ndtvimg.com/mt/cooks/2014-11/carrots.jpg",
+        productName: "제품 이름",
+        price: 50000,
+        count: 6,
+      },
+    ],
+  },
+  error: null,
+};

--- a/itda-front/tsconfig.json
+++ b/itda-front/tsconfig.json
@@ -1,21 +1,22 @@
 {
-	"compilerOptions": {
-		"baseUrl": "src",
-		"target": "es5",
-		"lib": ["dom", "dom.iterable", "esnext"],
-		"allowJs": true,
-		"skipLibCheck": true,
-		"esModuleInterop": true,
-		"allowSyntheticDefaultImports": true,
-		"strict": true,
-		"forceConsistentCasingInFileNames": true,
-		"noFallthroughCasesInSwitch": true,
-		"module": "esnext",
-		"moduleResolution": "node",
-		"resolveJsonModule": true,
-		"isolatedModules": true,
-		"noEmit": true,
-		"jsx": "react-jsx"
-	},
-	"include": ["src"]
+  "compilerOptions": {
+    "baseUrl": "src",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "downlevelIteration": true
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
## 📌 개요

set을 사용하여 장바구니 페이지 선택, 전체 선택/해제 기능 구현하였습니다.

## 👩‍💻 작업 사항
- 장바구니 페이지 선택, 전체 선택/해제 기능 
- Stepper 버튼 클릭에 따른 상품 금액 변경

## ✅ 참고 사항
- 아래 이미지에 보이는 것처럼 장바구니 선택 해제에 불필요한 리렌더링이 많이되어서 이부분 개선할 계획입니다.
- spread operator를 쓰다 typescript 오류가 생겨 tsconfig에`"downlevelIteration": true`를 추가해줬습니다.
![image](https://user-images.githubusercontent.com/56783350/129857011-86db8db5-2cce-4935-81e6-33d4bd2923bc.png)
![image](https://user-images.githubusercontent.com/56783350/129856907-c08df73e-ca5e-494e-bced-df94b22f2d02.png)

- atom 중 CounterButton의 이름을 StepperButton으로 수정하였습니다(찾아보니 Stepper가 정식이더라고요 ㅎㅎ)
- 장바구니 페이지가 처음 렌더링 될 때 [전체 선택 버튼이 선택되어있는 채 렌더링이 되는 오류가 있습니다!! 아직 버그 해결중입니다
공유할 내용, 스크린샷 등을 넣어 주세요.
![cart ](https://user-images.githubusercontent.com/56783350/129894097-01873327-1a84-4407-ae39-22cedeb45736.gif)
