### PR TITLE
[REFACTOR] Header isSticky prop 추가

### DIFF
--- a/itda-front/src/components/Products/Products.tsx
+++ b/itda-front/src/components/Products/Products.tsx
@@ -8,7 +8,7 @@ const Products = () => {
     <>
       <S.Products.HeaderLayout>
         <S.Products.HeaderLayer>
-          <Header />
+          <Header isSticky={true} />
         </S.Products.HeaderLayer>
         <Navigator />
       </S.Products.HeaderLayout>

--- a/itda-front/src/components/common/Header/Header.tsx
+++ b/itda-front/src/components/common/Header/Header.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-
 import S from "../CommonStyles";
 import SideDrawer from "./SideDrawer";
 import useScrollToggle from "hooks/useScrollToggle";
 
-const Header = () => {
+type THeader = {
+  isSticky?: boolean;
+};
+
+const Header = ({ isSticky = false }: THeader) => {
   const [isClicked, setIsClicked] = useState<undefined | boolean>(undefined);
   const scrollFlag = useScrollToggle(false);
 
@@ -20,8 +23,34 @@ const Header = () => {
     setIsClicked(true);
   };
 
-  return scrollFlag ? (
-    <></>
+  return isSticky ? (
+    scrollFlag ? (
+      <></>
+    ) : (
+      <S.Header.HeaderLayout>
+        <S.Header.HeaderLayer>
+          <S.Header.LeftBlock color={color}>
+            <S.Header.Navigation>
+              <Link to="/">홈</Link>
+            </S.Header.Navigation>
+            <S.Header.Navigation>
+              <Link to="/products">제품 소개</Link>
+            </S.Header.Navigation>
+            <S.Header.Navigation>
+              <Link to="/brandstory">브랜드 이야기</Link>
+            </S.Header.Navigation>
+          </S.Header.LeftBlock>
+          <S.Header.LogoBlock>
+            <S.Header.ItdaLogo color={color} />
+          </S.Header.LogoBlock>
+          <S.Header.RightBlock>
+            <S.Header.CartButton color={color} onClick={toggleSideDrawer} />
+            <S.Header.LoginButton color={color} />
+          </S.Header.RightBlock>
+        </S.Header.HeaderLayer>
+        <SideDrawer isClicked={isClicked} setIsClicked={setIsClicked} />
+      </S.Header.HeaderLayout>
+    )
   ) : (
     <S.Header.HeaderLayout>
       <S.Header.HeaderLayer>


### PR DESCRIPTION
## 📌 개요
-  products page에서 스크롤에 따라 header를 렌더하지 않는 기능이 필요하여 모든 헤더에 같은 기능을 추가하였는데, 스크롤을 할 때 버벅거리는 문제가 있어 Header 컴포넌트를 리팩토링 하였습니다.
- isSticky prop을 추가하여 isSticky가 true일 경우에만 스크롤 시 header를 렌더하지 않는 방식으로 리팩토링 했습니다.(default 는 false이기 때문에 false인 경우는 prop을 전달하지 않아도 됩니다)
- 현재까지 true가 들어가는 컴포넌트는 products page 뿐입니다.

## 👩‍💻 작업 사항

- [x] isSticky prop 추가
- [x] 전체 페이지 테스트

