### PR TITLE
[FIX] 장바구니 합계 계산 로직 구현 & 장바구니 아이템 개별 수량 변경 로직 수정(#112)

### DIFF
--- a/itda-front/src/components/common/CommonStyles.tsx
+++ b/itda-front/src/components/common/CommonStyles.tsx
@@ -343,7 +343,7 @@ const S = {
       color: #c2c2c2;
     `,
 
-    DrawerMoveToCartBtn: styled(Button)`
+    DrawerMoveToCartButton: styled(Button)`
       width: 100%;
       padding: 15px 0;
       background: ${({ theme }) => theme.colors.navy.light};

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -1,6 +1,5 @@
 import S from "../CommonStyles";
 import StepperButton from "components/common/Atoms/StepperButton";
-import StepperSubmitButton from "components/common/Atoms/StepperSubmitButton";
 import ProductCard from "../ProductCard";
 import { useRecoilState } from "recoil";
 import { useState, useEffect, SetStateAction } from "react";
@@ -32,7 +31,11 @@ const SideDrawer = ({ isClicked, setIsClicked }: TSideDrawer) => {
     setCartProductList(newProductData);
   };
 
-  const updateItemNumber = () => {};
+  const handleMoveToCartButtonClicked = () => {
+    //cartProductsCount의 수량과 cartProductList의 수량의 싱크 맞추기
+    // todo: POST요청으로 장바구니 데이터 서버에 전달
+    // todo: cart페이지로 이동
+  };
 
   useEffect(() => {
     setCartProductList(MockData);
@@ -43,12 +46,21 @@ const SideDrawer = ({ isClicked, setIsClicked }: TSideDrawer) => {
       (cartItem: ISendingCartProduct) => {
         return {
           id: cartItem.id,
+          price: cartItem.price,
           count: cartItem.count,
         };
       }
     );
     setCartProductsCount(cartItemCountArray);
   }, [cartProductList]);
+
+  useEffect(() => {
+    let total = 0;
+    cartProductsCount.forEach((cartItem) => {
+      total += cartItem.price * cartItem.count;
+    });
+    setCartTotalPrice(total);
+  }, [cartProductsCount]);
 
   return (
     <S.SideDrawer.DrawerLayout isClicked={isClicked}>
@@ -85,9 +97,11 @@ const SideDrawer = ({ isClicked, setIsClicked }: TSideDrawer) => {
         <S.SideDrawer.DrawerDeliveryFee>
           (배송비 불포함 금액)
         </S.SideDrawer.DrawerDeliveryFee>
-        <S.SideDrawer.DrawerMoveToCartBtn>
+        <S.SideDrawer.DrawerMoveToCartButton
+          onClick={handleMoveToCartButtonClicked}
+        >
           장바구니로 이동
-        </S.SideDrawer.DrawerMoveToCartBtn>
+        </S.SideDrawer.DrawerMoveToCartButton>
       </S.SideDrawer.DrawerBottom>
     </S.SideDrawer.DrawerLayout>
   );
@@ -119,11 +133,10 @@ const SideDrawerItem = ({
     cartProductsCount.filter((cartItem) => cartItem.id === productId)[0].count
   );
 
-  const updateItemNumber = () => {};
-
   useEffect(() => {
     const newCount = {
       id: productId,
+      price: productPrice,
       count: productCount,
     };
     const updatedCartProductsCount = cartProductsCount.map((cartItem) => {
@@ -146,7 +159,6 @@ const SideDrawerItem = ({
         <S.SideDrawer.DrawerCardDescription>
           <div>
             <StepperButton state={productCount} setState={setProductCount} />
-            <StepperSubmitButton onClick={updateItemNumber} />
           </div>
         </S.SideDrawer.DrawerCardDescription>
       </S.SideDrawer.DrawerCardCountDiv>

--- a/itda-front/src/stores/CartAtoms.ts
+++ b/itda-front/src/stores/CartAtoms.ts
@@ -1,5 +1,5 @@
 import { atom, selector } from "recoil";
-import { ICartProduct } from "types/CartTypes";
+import { ICartProduct, ISendingCartProduct } from "types/CartTypes";
 
 export const selectedProduct = atom({
   key: "selectedProduct",
@@ -8,5 +8,10 @@ export const selectedProduct = atom({
 
 export const cartProductData = atom<ICartProduct[]>({
   key: "cartProductData",
+  default: [],
+});
+
+export const sendingCartProductData = atom<ISendingCartProduct[]>({
+  key: "sendingCartProductData",
   default: [],
 });

--- a/itda-front/src/stores/CartAtoms.ts
+++ b/itda-front/src/stores/CartAtoms.ts
@@ -10,8 +10,3 @@ export const cartProductData = atom<ICartProduct[]>({
   key: "cartProductData",
   default: [],
 });
-
-export const sendingCartProductData = atom<ISendingCartProduct[]>({
-  key: "sendingCartProductData",
-  default: [],
-});

--- a/itda-front/src/types/CartTypes.ts
+++ b/itda-front/src/types/CartTypes.ts
@@ -6,4 +6,9 @@ interface ICartProduct {
   count: number;
 }
 
-export type { ICartProduct };
+interface ISendingCartProduct {
+  id: number;
+  count: number;
+}
+
+export type { ICartProduct, ISendingCartProduct };

--- a/itda-front/src/types/CartTypes.ts
+++ b/itda-front/src/types/CartTypes.ts
@@ -8,6 +8,7 @@ interface ICartProduct {
 
 interface ISendingCartProduct {
   id: number;
+  price: number;
   count: number;
 }
 


### PR DESCRIPTION
## 📌 개요

- Close #112 
장바구니 합계 계산 로직 구현 & 장바구니 아이템 개별 수량 변경 로직 수정

## 👩‍💻 작업 사항

- [x] SideDrawer총합 데이터 계산 로직 구현
- [x] StepperButton 클릭 시 각 아이템의 수량 데이터 정정되는 로직 구현하기

## ✅ 참고 사항
[ 변경된 부분 ]
- 원래는 SideDrawer의 모든 아이템의 stepper 버튼 우측에 변경버튼(StepperSubmitButton)을 추가했었는데, UX 측면에서 아이템의 수량을 변경하고 일일이 변경 버튼을 누르는 것이 번거롭기도 하고, POST요청이 과다하게 갈 것 같아 변경버튼을 삭제했어요. 내부적으로는 `장바구니로 이동` 버튼이 클릭되면 상태가 한번에 업데이트 되어서 POST 요청이 가면 될 것 같습니다~!
- 전역으로 관리되고 있는 `cartProductData`이외에 장바구니 데이터 업데이트를 서버에 요청할 때 POST양식에 맞춘 `sendingCartProductData`상태를 로컬에 별도로 추가했습니다.

![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/65105537/131390267-9ce5fb2b-4dc7-4487-95ca-3c8d9e4c2994.gif)
