### PR TITLE
[FEAT] Address Form Modal View 구현

### DIFF
--- a/itda-front/src/components/Cart/AddressForm/AddressForm.tsx
+++ b/itda-front/src/components/Cart/AddressForm/AddressForm.tsx
@@ -1,0 +1,6 @@
+import AddressFormModal from "./AddressFormModal";
+const AddressForm = () => {
+  return <>{<AddressFormModal />}</>;
+};
+
+export default AddressForm;

--- a/itda-front/src/components/Cart/AddressForm/AddressFormModal.tsx
+++ b/itda-front/src/components/Cart/AddressForm/AddressFormModal.tsx
@@ -1,0 +1,69 @@
+import S from "../CartStyles";
+import GradientButton from "components/common/Atoms/GradientButton";
+import AddressSelection from "./AddressSelection";
+import LastAddressSelection from "./LastAddressSelection";
+import NewAddressForm from "./NewAddressForm/";
+import DefaultAddressForm from "./DefaultAddressForm";
+import DeliveryRequestForm from "./DeliveryRequestForm";
+import CancelButton from "components/common/Atoms/CancelButton";
+const AddressFormModal = () => {
+  const saveAddressInfo = () => {};
+  return (
+    <>
+      <S.AddressFormModal.Layout>
+        <S.AddressFormModal.Header>
+          <S.AddressFormModal.Title>
+            배송지 정보
+            <S.AddressFormModal.CancelLayer>
+              <CancelButton hoverEffect={false} />
+            </S.AddressFormModal.CancelLayer>
+          </S.AddressFormModal.Title>
+        </S.AddressFormModal.Header>
+        <S.AddressFormModal.Main>
+          <S.AddressFormModal.Layer>
+            <S.AddressFormModal.SubTitle>
+              배송지 선택
+            </S.AddressFormModal.SubTitle>
+            <AddressSelection />
+          </S.AddressFormModal.Layer>
+          <S.AddressFormModal.Layer>
+            <S.AddressFormModal.SubTitle>
+              최근 배송지
+            </S.AddressFormModal.SubTitle>
+            <LastAddressSelection />
+          </S.AddressFormModal.Layer>
+          <NewAddressForm />
+          {/* <DefaultAddressForm /> */}
+          {/* 스위칭 */}
+          <S.AddressFormModal.Layer>
+            <S.AddressFormModal.SubTitle>
+              배송메모(선택)
+            </S.AddressFormModal.SubTitle>
+            <DeliveryRequestForm />
+          </S.AddressFormModal.Layer>
+          <S.AddressSearchForm.BottomLayer>
+            <GradientButton width={"200px"} onClick={saveAddressInfo}>
+              저장하기
+            </GradientButton>
+          </S.AddressSearchForm.BottomLayer>
+        </S.AddressFormModal.Main>
+      </S.AddressFormModal.Layout>
+    </>
+  );
+};
+
+export default AddressFormModal;
+
+//GET기본 주소지와 최근 4개 주소지 조회
+// {
+// 	"consignee": "크롱",
+// 	"phone": "01040207042",
+//     "regionOneDepthName":"서울특별시" ,
+//     "regionTwoDepthName":"강남구",
+// 	"regionThreeDepthName":"역삼동",
+// 	"mainBuildingNo":40,
+// 	"subBuildingNo":4,
+// 	"zoneNo": 36680,
+// 	"defaultAddrYn": true,
+//     "message": "문 앞에 놓고 전화주세요."
+// }

--- a/itda-front/src/components/Cart/AddressForm/AddressSelection.tsx
+++ b/itda-front/src/components/Cart/AddressForm/AddressSelection.tsx
@@ -1,0 +1,23 @@
+import RadioButton from "components/common/Atoms/RadioButton";
+import { useState } from "react";
+import S from "../CartStyles";
+
+const AddressSelection = () => {
+  const [state, setSelectedState] = useState("test");
+  return (
+    <S.AddressSelection.Layout>
+      <RadioButton
+        value={"기본 배송지"}
+        state={state}
+        setState={setSelectedState}
+      />
+      <RadioButton
+        value={"신규 배송지"}
+        state={state}
+        setState={setSelectedState}
+      />
+    </S.AddressSelection.Layout>
+  );
+};
+
+export default AddressSelection;

--- a/itda-front/src/components/Cart/AddressForm/DefaultAddressForm.tsx
+++ b/itda-front/src/components/Cart/AddressForm/DefaultAddressForm.tsx
@@ -1,0 +1,13 @@
+import S from "components/Cart/CartStyles";
+
+const DefaultAddressForm = () => {
+  return (
+    <>
+      <div>김크롱 (김크롱)</div>
+      <div>010-1234-5678</div>
+      <div>(우편번호) 서울특별시 ~~구 ~~길 12-2 (상세 주소 ~~ )</div>
+    </>
+  );
+};
+
+export default DefaultAddressForm;

--- a/itda-front/src/components/Cart/AddressForm/DeliveryRequestForm.tsx
+++ b/itda-front/src/components/Cart/AddressForm/DeliveryRequestForm.tsx
@@ -1,0 +1,7 @@
+import TextInput from "components/common/Atoms/TextInput";
+
+const DeliveryRequestForm = () => {
+  return <TextInput width={"large"} />;
+};
+
+export default DeliveryRequestForm;

--- a/itda-front/src/components/Cart/AddressForm/DeliveryRequestForm.tsx
+++ b/itda-front/src/components/Cart/AddressForm/DeliveryRequestForm.tsx
@@ -1,7 +1,16 @@
 import TextInput from "components/common/Atoms/TextInput";
+import { useState } from "react";
 
 const DeliveryRequestForm = () => {
-  return <TextInput width={"large"} />;
+  const [inputState, setInputState] = useState(""); //임시 상태
+  return (
+    <TextInput
+      width={"400px"}
+      isRequired={false}
+      state={inputState}
+      setState={setInputState}
+    />
+  );
 };
 
 export default DeliveryRequestForm;

--- a/itda-front/src/components/Cart/AddressForm/LastAddressSelection.tsx
+++ b/itda-front/src/components/Cart/AddressForm/LastAddressSelection.tsx
@@ -1,0 +1,33 @@
+import RadioButtonWithCancel from "components/common/Atoms/RadioButtonWithCancel";
+import { useState } from "react";
+import S from "../CartStyles";
+
+const LastAddressSelection = () => {
+  const [state, setSelectedState] = useState("test");
+  return (
+    <S.LastAddressSelection.Layout>
+      <RadioButtonWithCancel
+        value={"크롱이네"}
+        state={state}
+        setState={setSelectedState}
+      />
+      <RadioButtonWithCancel
+        value={"재롱이네"}
+        state={state}
+        setState={setSelectedState}
+      />
+      <RadioButtonWithCancel
+        value={"메롱이네"}
+        state={state}
+        setState={setSelectedState}
+      />
+      <RadioButtonWithCancel
+        value={"아롱이네"}
+        state={state}
+        setState={setSelectedState}
+      />
+    </S.LastAddressSelection.Layout>
+  );
+};
+
+export default LastAddressSelection;

--- a/itda-front/src/components/Cart/AddressForm/NewAddressForm/AddressSearchForm.tsx
+++ b/itda-front/src/components/Cart/AddressForm/NewAddressForm/AddressSearchForm.tsx
@@ -1,0 +1,21 @@
+import TextInput from "components/common/Atoms/TextInput";
+import S from "components/Cart/CartStyles";
+import { useState } from "react";
+const AddressSearchForm = () => {
+  return (
+    <div>
+      <S.AddressSearchForm.LineLayer>
+        <TextInput />
+        <S.AddressSearchForm.SearchButton>
+          검색
+        </S.AddressSearchForm.SearchButton>
+      </S.AddressSearchForm.LineLayer>
+      <S.AddressSearchForm.LineLayer>
+        <TextInput width={"medium"} />
+        <TextInput width={"medium"} />
+      </S.AddressSearchForm.LineLayer>
+    </div>
+  );
+};
+
+export default AddressSearchForm;

--- a/itda-front/src/components/Cart/AddressForm/NewAddressForm/AddressSearchForm.tsx
+++ b/itda-front/src/components/Cart/AddressForm/NewAddressForm/AddressSearchForm.tsx
@@ -2,17 +2,30 @@ import TextInput from "components/common/Atoms/TextInput";
 import S from "components/Cart/CartStyles";
 import { useState } from "react";
 const AddressSearchForm = () => {
+  const [inputState, setInputState] = useState(""); //임시 상태
   return (
     <div>
       <S.AddressSearchForm.LineLayer>
-        <TextInput />
+        <TextInput
+          width={"100px"}
+          state={inputState}
+          setState={setInputState}
+        />
         <S.AddressSearchForm.SearchButton>
           검색
         </S.AddressSearchForm.SearchButton>
       </S.AddressSearchForm.LineLayer>
       <S.AddressSearchForm.LineLayer>
-        <TextInput width={"medium"} />
-        <TextInput width={"medium"} />
+        <TextInput
+          width={"100px"}
+          state={inputState}
+          setState={setInputState}
+        />
+        <TextInput
+          width={"200px"}
+          state={inputState}
+          setState={setInputState}
+        />
       </S.AddressSearchForm.LineLayer>
     </div>
   );

--- a/itda-front/src/components/Cart/AddressForm/NewAddressForm/NewAddressForm.tsx
+++ b/itda-front/src/components/Cart/AddressForm/NewAddressForm/NewAddressForm.tsx
@@ -2,12 +2,18 @@ import S from "components/Cart/CartStyles";
 import TextInput from "components/common/Atoms/TextInput";
 import PhoneNumberForm from "components/Cart/AddressForm/NewAddressForm/PhoneNumberForm";
 import AddressSearchForm from "./AddressSearchForm";
+import { useState } from "react";
 const NewAddressForm = () => {
+  const [inputState, setInputState] = useState(""); //임시 상태
   return (
     <>
       <S.AddressFormModal.Layer>
         <S.AddressFormModal.SubTitle>수령인</S.AddressFormModal.SubTitle>
-        <TextInput />
+        <TextInput
+          state={inputState}
+          setState={setInputState}
+          width={"100px"}
+        />
       </S.AddressFormModal.Layer>
       <S.AddressFormModal.Layer>
         <S.AddressFormModal.SubTitle>연락처</S.AddressFormModal.SubTitle>

--- a/itda-front/src/components/Cart/AddressForm/NewAddressForm/NewAddressForm.tsx
+++ b/itda-front/src/components/Cart/AddressForm/NewAddressForm/NewAddressForm.tsx
@@ -1,0 +1,24 @@
+import S from "components/Cart/CartStyles";
+import TextInput from "components/common/Atoms/TextInput";
+import PhoneNumberForm from "components/Cart/AddressForm/NewAddressForm/PhoneNumberForm";
+import AddressSearchForm from "./AddressSearchForm";
+const NewAddressForm = () => {
+  return (
+    <>
+      <S.AddressFormModal.Layer>
+        <S.AddressFormModal.SubTitle>수령인</S.AddressFormModal.SubTitle>
+        <TextInput />
+      </S.AddressFormModal.Layer>
+      <S.AddressFormModal.Layer>
+        <S.AddressFormModal.SubTitle>연락처</S.AddressFormModal.SubTitle>
+        <PhoneNumberForm />
+      </S.AddressFormModal.Layer>
+      <S.AddressFormModal.Layer>
+        <S.AddressFormModal.SubTitle>주소</S.AddressFormModal.SubTitle>
+        <AddressSearchForm />
+      </S.AddressFormModal.Layer>
+    </>
+  );
+};
+
+export default NewAddressForm;

--- a/itda-front/src/components/Cart/AddressForm/NewAddressForm/PhoneNumberForm.tsx
+++ b/itda-front/src/components/Cart/AddressForm/NewAddressForm/PhoneNumberForm.tsx
@@ -1,0 +1,16 @@
+import SelectBox from "components/common/Atoms/SelectBox";
+import TextInput from "components/common/Atoms/TextInput";
+const PhoneNumberForm = () => {
+  const numberList = ["010", "02", "031"];
+  return (
+    <>
+      <SelectBox selectArray={numberList} />
+      -
+      <TextInput width={"small"} />
+      -
+      <TextInput width={"small"} />
+    </>
+  );
+};
+
+export default PhoneNumberForm;

--- a/itda-front/src/components/Cart/AddressForm/NewAddressForm/PhoneNumberForm.tsx
+++ b/itda-front/src/components/Cart/AddressForm/NewAddressForm/PhoneNumberForm.tsx
@@ -1,14 +1,17 @@
 import SelectBox from "components/common/Atoms/SelectBox";
 import TextInput from "components/common/Atoms/TextInput";
+import { useState } from "react";
+
 const PhoneNumberForm = () => {
+  const [inputState, setInputState] = useState(""); //임시 상태
   const numberList = ["010", "02", "031"];
   return (
     <>
       <SelectBox selectArray={numberList} />
       -
-      <TextInput width={"small"} />
+      <TextInput width={"100px"} state={inputState} setState={setInputState} />
       -
-      <TextInput width={"small"} />
+      <TextInput width={"100px"} state={inputState} setState={setInputState} />
     </>
   );
 };

--- a/itda-front/src/components/Cart/AddressForm/NewAddressForm/index.ts
+++ b/itda-front/src/components/Cart/AddressForm/NewAddressForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NewAddressForm";

--- a/itda-front/src/components/Cart/AddressForm/index.ts
+++ b/itda-front/src/components/Cart/AddressForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AddressForm";

--- a/itda-front/src/components/Cart/AddressInfo.tsx
+++ b/itda-front/src/components/Cart/AddressInfo.tsx
@@ -1,12 +1,15 @@
-import S from "../CartStyles";
+import S from "./CartStyles";
 import GradientButton from "components/common/Atoms/GradientButton";
 
 const AddressInfo = () => {
+  const showAddressFormModal = () => {};
   return (
     <S.AddressInfo.Layout>
       <S.AddressInfo.Title>배송지</S.AddressInfo.Title>
       <S.AddressInfo.Contents>배송지를 입력해주세요. </S.AddressInfo.Contents>
-      <GradientButton width={"18rem"}>배송지 입력</GradientButton>
+      <GradientButton width={"18rem"} onClick={showAddressFormModal}>
+        배송지 입력
+      </GradientButton>
     </S.AddressInfo.Layout>
   );
 };

--- a/itda-front/src/components/Cart/AddressInfo/AddressFormModal.tsx
+++ b/itda-front/src/components/Cart/AddressInfo/AddressFormModal.tsx
@@ -1,6 +1,0 @@
-import S from "../CartStyles";
-const AddressFormModal = () => {
-  return <div></div>;
-};
-
-export default AddressFormModal;

--- a/itda-front/src/components/Cart/AddressInfo/index.ts
+++ b/itda-front/src/components/Cart/AddressInfo/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./AddressInfo";

--- a/itda-front/src/components/Cart/Cart.tsx
+++ b/itda-front/src/components/Cart/Cart.tsx
@@ -6,7 +6,7 @@ import CartProduct from "./CartProduct/";
 import AddressForm from "./AddressForm";
 const Cart = () => {
   return (
-    <>
+    <S.Cart.Layout>
       <S.AddressFormModal.BlackBackground />
       {/* 모달 클릭 여부에 따라 리턴 */}
       <S.Cart.HeaderLayout>
@@ -28,7 +28,7 @@ const Cart = () => {
           </S.Cart.SummaryLayer>
         </S.Cart.ContainerLayer>
       </S.Cart.MainLayout>
-    </>
+    </S.Cart.Layout>
   );
 };
 

--- a/itda-front/src/components/Cart/Cart.tsx
+++ b/itda-front/src/components/Cart/Cart.tsx
@@ -3,13 +3,18 @@ import Header from "components/common/Header";
 import AddressInfo from "./AddressInfo";
 import PaymentInfo from "./PaymentInfo";
 import CartProduct from "./CartProduct/";
-
+import AddressForm from "./AddressForm";
 const Cart = () => {
   return (
     <>
+      <S.AddressFormModal.BlackBackground />
+      {/* 모달 클릭 여부에 따라 리턴 */}
       <S.Cart.HeaderLayout>
         <Header />
       </S.Cart.HeaderLayout>
+      <S.Cart.ModalLayout>
+        <AddressForm />
+      </S.Cart.ModalLayout>
       <S.Cart.CartHeaderLayout>장바구니</S.Cart.CartHeaderLayout>
       <S.Cart.MainLayout>
         <S.Cart.ContainerLayer>

--- a/itda-front/src/components/Cart/CartStyles.tsx
+++ b/itda-front/src/components/Cart/CartStyles.tsx
@@ -2,6 +2,10 @@ import styled from "styled-components";
 import { GrDeliver } from "react-icons/gr";
 const S = {
   Cart: {
+    ModalLayout: styled.div`
+      display: flex;
+      justify-content: center;
+    `,
     CartHeaderLayout: styled.div`
       display: flex;
       justify-content: center;
@@ -94,7 +98,69 @@ const S = {
     `,
   },
 
-  AddressFormModal: {},
+  AddressFormModal: {
+    Layout: styled.div`
+      z-index: 2;
+      width: 800px;
+      height: 600px;
+      background-color: ${({ theme }) => theme.colors.blue.extraLight};
+      border: 1px solid ${({ theme }) => theme.colors.gray.light};
+      border-radius: 10px;
+      position: absolute;
+    `,
+    Layer: styled.div`
+      display: flex;
+      align-items: center;
+      padding: 10px 0;
+    `,
+    CancelLayer: styled.div`
+      position: absolute;
+      right: 10px;
+    `,
+    Header: styled.header``,
+    Main: styled.main`
+      padding: 20px 100px;
+    `,
+    Title: styled.div`
+      display: flex;
+      position: relative;
+      justify-content: center;
+      padding: 10px 0px;
+      font-size: 1.7rem;
+      font-weight: bold;
+      background-color: ${({ theme }) => theme.colors.navy.normal};
+      border-top-right-radius: 10px;
+      border-top-left-radius: 10px;
+      color: ${({ theme }) => theme.colors.white};
+    `,
+
+    SubTitle: styled.div`
+      display: flex;
+      align-items: center;
+      padding-right: 20px;
+      width: 10rem;
+    `,
+
+    BlackBackground: styled.div`
+      position: fixed;
+      z-index: 1;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.7);
+    `,
+  },
+
+  AddressSelection: {
+    Layout: styled.div`
+      display: flex;
+    `,
+  },
+  LastAddressSelection: {
+    Layout: styled.div`
+      display: flex;
+    `,
+  },
+
   PaymentInfo: {
     Layout: styled.div`
       padding: 2rem 0;
@@ -125,6 +191,29 @@ const S = {
       height: 4rem;
       width: 18rem;
       border-radius: 0.4rem;
+    `,
+  },
+  AddressSearchForm: {
+    LineLayer: styled.div`
+      display: flex;
+      align-items: center;
+      padding-bottom: 10px;
+    `,
+
+    SearchButton: styled.button`
+      height: 2.5rem;
+      border-radius: 5px;
+      border: 1px solid ${({ theme }) => theme.colors.mint.normal};
+      background-color: ${({ theme }) => theme.colors.white};
+      color: ${({ theme }) => theme.colors.mint.normal};
+      font-size: ${({ theme }) => theme.fontSizes.small};
+    `,
+
+    BottomLayer: styled.div`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 50px 0px;
     `,
   },
 };

--- a/itda-front/src/components/Cart/CartStyles.tsx
+++ b/itda-front/src/components/Cart/CartStyles.tsx
@@ -2,6 +2,9 @@ import styled from "styled-components";
 import { GrDeliver } from "react-icons/gr";
 const S = {
   Cart: {
+    Layout: styled.div`
+      overflow-x: hidden;
+    `,
     ModalLayout: styled.div`
       display: flex;
       justify-content: center;

--- a/itda-front/src/components/Products/Navigator/SearchBar.tsx
+++ b/itda-front/src/components/Products/Navigator/SearchBar.tsx
@@ -5,71 +5,72 @@ import { makeStyles } from "@material-ui/core/styles";
 import FormControl from "@material-ui/core/FormControl";
 import MenuItem from "@material-ui/core/MenuItem";
 import Select from "@material-ui/core/Select";
-import { ESearchCriteria } from "types/enums/searchBar";
+import { ESearchCriteria } from "types/SearchBar";
+
 const useStyles = makeStyles(theme => ({
-	formControl: {
-		margin: theme.spacing(1),
-		minWidth: 100,
-		textAlign: "center",
-	},
-	selectEmpty: {
-		marginTop: theme.spacing(2),
-	},
+  formControl: {
+    margin: theme.spacing(1),
+    minWidth: 100,
+    textAlign: "center",
+  },
+  selectEmpty: {
+    marginTop: theme.spacing(2),
+  },
 }));
 
 const SearchBar = () => {
-	const classes = useStyles();
-	const [searchCriteria, setSearchCriteria] = useState("PRODUCT");
-	const [searchInputState, setSearchInputState] = useState("");
-	const [searchTerm, setSearchTerm] = useState("");
+  const classes = useStyles();
+  const [searchCriteria, setSearchCriteria] = useState("PRODUCT");
+  const [searchInputState, setSearchInputState] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
 
-	const handleSelectChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-		setSearchCriteria(event.target.value as string);
-	};
-	const handleInputChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-		setSearchInputState(event.target.value as string);
-	};
-	const handleSearchButtonClick = () => setSearchTerm(searchInputState);
+  const handleSelectChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setSearchCriteria(event.target.value as string);
+  };
+  const handleInputChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setSearchInputState(event.target.value as string);
+  };
+  const handleSearchButtonClick = () => setSearchTerm(searchInputState);
 
-	const handleSearchBarKeyEvent = (
-		event: React.KeyboardEvent<HTMLDivElement>
-	) => event.key === "Enter" && setSearchTerm(searchInputState);
+  const handleSearchBarKeyEvent = (
+    event: React.KeyboardEvent<HTMLDivElement>
+  ) => event.key === "Enter" && setSearchTerm(searchInputState);
 
-	const getQueryString = () => {
-		if (searchCriteria === ESearchCriteria.PRODUCT)
-			return `productName=${searchTerm}`;
-		else if (searchCriteria === ESearchCriteria.SELLER)
-			return `sellerName=${searchTerm}`;
-	};
-	return (
-		<>
-			{searchTerm && <Redirect to={`/products?${getQueryString()}`} />}
-			<S.SearchBar.Layer>
-				<FormControl className={classes.formControl}>
-					<Select
-						labelId="demo-simple-select-label"
-						id="demo-simple-select"
-						value={searchCriteria}
-						onChange={handleSelectChange}
-					>
-						<MenuItem value={ESearchCriteria.PRODUCT}>제품명</MenuItem>
-						<MenuItem value={ESearchCriteria.SELLER}>판매자</MenuItem>
-					</Select>
-				</FormControl>
-				<S.SearchBar.InputLayer>
-					<S.SearchBar.Input
-						placeholder={"검색어를 입력해주세요."}
-						autoComplete="off"
-						value={searchInputState}
-						onChange={handleInputChange}
-						onKeyPress={handleSearchBarKeyEvent}
-					/>
+  const getQueryString = () => {
+    if (searchCriteria === ESearchCriteria.PRODUCT)
+      return `productName=${searchTerm}`;
+    else if (searchCriteria === ESearchCriteria.SELLER)
+      return `sellerName=${searchTerm}`;
+  };
+  return (
+    <>
+      {searchTerm && <Redirect to={`/products?${getQueryString()}`} />}
+      <S.SearchBar.Layer>
+        <FormControl className={classes.formControl}>
+          <Select
+            labelId="demo-simple-select-label"
+            id="demo-simple-select"
+            value={searchCriteria}
+            onChange={handleSelectChange}
+          >
+            <MenuItem value={ESearchCriteria.PRODUCT}>제품명</MenuItem>
+            <MenuItem value={ESearchCriteria.SELLER}>판매자</MenuItem>
+          </Select>
+        </FormControl>
+        <S.SearchBar.InputLayer>
+          <S.SearchBar.Input
+            placeholder={"검색어를 입력해주세요."}
+            autoComplete="off"
+            value={searchInputState}
+            onChange={handleInputChange}
+            onKeyPress={handleSearchBarKeyEvent}
+          />
 
-					<S.SearchBar.SearchButton onClick={handleSearchButtonClick} />
-				</S.SearchBar.InputLayer>
-			</S.SearchBar.Layer>
-		</>
-	);
+          <S.SearchBar.SearchButton onClick={handleSearchButtonClick} />
+        </S.SearchBar.InputLayer>
+      </S.SearchBar.Layer>
+    </>
+  );
 };
 
 export default SearchBar;

--- a/itda-front/src/components/common/Atoms/AtomsStyles.tsx
+++ b/itda-front/src/components/common/Atoms/AtomsStyles.tsx
@@ -144,17 +144,9 @@ const S = {
     `,
   },
 
-  TextInput: {
-    Small: styled(TextField)`
-      width: 100px;
-    `,
-    Medium: styled(TextField)`
-      width: 200px;
-    `,
-    Large: styled(TextField)`
-      width: 400px;
-    `,
-  },
+  TextInput: styled(TextField)<{ width: string }>`
+    width: ${({ width }) => width};
+  `,
   SelectBox: {
     NativeSelect: styled(NativeSelect)`
       border: 1px solid ${({ theme }) => theme.colors.gray.light};

--- a/itda-front/src/components/common/Atoms/AtomsStyles.tsx
+++ b/itda-front/src/components/common/Atoms/AtomsStyles.tsx
@@ -6,7 +6,9 @@ import {
 import { HiX } from "react-icons/hi";
 import { FaPlus, FaMinus } from "react-icons/fa";
 import Button from "@material-ui/core/Button";
-import theme from "styles/theme";
+import Radio from "@material-ui/core/Radio";
+import TextField from "@material-ui/core/TextField";
+import NativeSelect from "@material-ui/core/NativeSelect";
 const S = {
   StepperButton: {
     Layout: styled.div`
@@ -27,7 +29,6 @@ const S = {
         justify-content: center;
         align-items: center;
         width: 2rem;
-
         background: none;
         font-weight: bold;
       }
@@ -56,11 +57,14 @@ const S = {
     `,
   },
   CancelButton: {
-    Icon: styled(HiX)`
+    Icon: styled(HiX)<{ hoverEffect?: boolean }>`
       color: ${({ theme }) => theme.colors.gray.light};
       cursor: pointer;
       :hover {
-        color: ${({ theme }) => theme.colors.navy.normal};
+        color: ${props =>
+          props.hoverEffect
+            ? props.theme.colors.navy.normal
+            : props.theme.colors.gray.light};
       }
     `,
   },
@@ -113,6 +117,52 @@ const S = {
       color: ${({ theme }) => theme.colors.mint.normal};
     }
   `,
+  RadioButton: {
+    Layout: styled.div`
+      display: flex;
+      align-items: center;
+    `,
+    Button: styled(Radio)`
+      color: ${({ theme }) => theme.colors.mint.normal};
+      padding: 1px;
+    `,
+    Text: styled.div`
+      font-size: 13px;
+    `,
+  },
+  RadioButtonWithCancel: {
+    Layout: styled.div`
+      display: flex;
+      align-items: center;
+    `,
+    Button: styled(Radio)`
+      color: ${({ theme }) => theme.colors.mint.normal};
+      padding: 1px;
+    `,
+    Text: styled.div`
+      font-size: 13px;
+    `,
+  },
+
+  TextInput: {
+    Small: styled(TextField)`
+      width: 100px;
+    `,
+    Medium: styled(TextField)`
+      width: 200px;
+    `,
+    Large: styled(TextField)`
+      width: 400px;
+    `,
+  },
+  SelectBox: {
+    NativeSelect: styled(NativeSelect)`
+      border: 1px solid ${({ theme }) => theme.colors.gray.light};
+      padding: 3px 10px;
+      border-radius: 4px;
+      background-color: none;
+    `,
+  },
 };
 
 export default S;

--- a/itda-front/src/components/common/Atoms/CancelButton.tsx
+++ b/itda-front/src/components/common/Atoms/CancelButton.tsx
@@ -2,10 +2,11 @@ import S from "./AtomsStyles";
 
 type TCheckButton = {
   onClick?: React.MouseEventHandler<SVGElement>;
+  hoverEffect?: boolean;
 };
 
-const CancelButton = ({ onClick }: TCheckButton) => {
-  return <S.CancelButton.Icon onClick={onClick} />;
+const CancelButton = ({ onClick, hoverEffect = true }: TCheckButton) => {
+  return <S.CancelButton.Icon onClick={onClick} hoverEffect={hoverEffect} />;
 };
 
 export default CancelButton;

--- a/itda-front/src/components/common/Atoms/ConfirmModal.tsx
+++ b/itda-front/src/components/common/Atoms/ConfirmModal.tsx
@@ -1,0 +1,5 @@
+const ConfirmModal = () => {
+  return <div></div>;
+};
+
+export default ConfirmModal;

--- a/itda-front/src/components/common/Atoms/RadioButton.tsx
+++ b/itda-front/src/components/common/Atoms/RadioButton.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import S from "./AtomsStyles";
+
+type TRadioButton = {
+  value: string;
+  state: string;
+  setState: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const RadioButton = ({ value, state, setState }: TRadioButton) => {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setState(event.target.value);
+  };
+
+  return (
+    <S.RadioButton.Layout>
+      <S.RadioButton.Button
+        checked={state === value}
+        onChange={handleChange}
+        value={value}
+        color="default"
+      />
+      <S.RadioButton.Text>{value}</S.RadioButton.Text>
+    </S.RadioButton.Layout>
+  );
+};
+
+export default RadioButton;

--- a/itda-front/src/components/common/Atoms/RadioButtonWithCancel.tsx
+++ b/itda-front/src/components/common/Atoms/RadioButtonWithCancel.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import S from "./AtomsStyles";
+import CancelButton from "components/common/Atoms/CancelButton";
+
+type TRadioButton = {
+  value: string;
+  state: string;
+  setState: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const RadioButtonWithCancel = ({ value, state, setState }: TRadioButton) => {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setState(event.target.value);
+  };
+
+  return (
+    <S.RadioButton.Layout>
+      <S.RadioButton.Button
+        checked={state === value}
+        onChange={handleChange}
+        value={value}
+        color="default"
+      />
+      <S.RadioButton.Text>{value}</S.RadioButton.Text>
+      <CancelButton></CancelButton>
+    </S.RadioButton.Layout>
+  );
+};
+
+export default RadioButtonWithCancel;

--- a/itda-front/src/components/common/Atoms/SelectBox.tsx
+++ b/itda-front/src/components/common/Atoms/SelectBox.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+
+import S from "./AtomsStyles";
+
+type TSelectBox = {
+  selectArray: string[];
+};
+
+const SelectBox = ({ selectArray }: TSelectBox) => {
+  const [state, setState] = useState(""); //state 밖에서 받아오기
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setState(event.target.value as string);
+  };
+  const options = selectArray.map(value => (
+    <option value={value}>{value}</option>
+  ));
+
+  return (
+    <S.SelectBox.NativeSelect onChange={handleChange}>
+      {options}
+    </S.SelectBox.NativeSelect>
+  );
+};
+
+export default SelectBox;

--- a/itda-front/src/components/common/Atoms/TextInput.tsx
+++ b/itda-front/src/components/common/Atoms/TextInput.tsx
@@ -1,67 +1,44 @@
 import S from "./AtomsStyles";
-import { useState } from "react";
 
 type TTextInput = {
   label?: string | number;
   variant?: "outlined" | "filled" | "standard";
   size?: "small" | "medium";
-  width?: "small" | "medium" | "large";
+  width?: string;
+  isRequired?: boolean;
+  state: string;
+  setState: (input: string) => void; //textInput이니 string 타입을 상태로 가지게 했습니다.(변경가능)
 };
 
 const TextInput = ({
   label,
-  size = "small",
+  size = "small", //size가 아닌 height로는 높이 조정이 불가능해서 주어진 높이 관련 속성인 size로 정했습니다.
   variant = "outlined",
-  width = "small",
+  width = "100px",
+  isRequired = true,
+  state,
+  setState,
 }: TTextInput) => {
-  const [inputState, setInputState] = useState("");
-  const handleError = () => {
-    return inputState === "" ? true : false; //왜 안되지
+  const handleEmptyInput = () => {
+    //공백일 때 false를 반환합니다.
+    return isRequired && state === "" ? true : false;
   };
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputState(e.target.value);
+    setState(e.target.value);
   };
 
-  const getCustomInput = () => {
-    switch (width) {
-      case "small": {
-        return (
-          <S.TextInput.Small
-            error={handleError()}
-            type="text"
-            label={label}
-            variant={variant}
-            size={size}
-            onChange={handleInputChange}
-          />
-        );
-      }
-      case "medium": {
-        return (
-          <S.TextInput.Medium
-            type="text"
-            label={label}
-            variant={variant}
-            size={size}
-            onChange={handleInputChange}
-          />
-        );
-      }
-      case "large": {
-        return (
-          <S.TextInput.Large
-            type="text"
-            label={label}
-            variant={variant}
-            size={size}
-            onChange={handleInputChange}
-          />
-        );
-      }
-    }
-  };
-
-  return <>{getCustomInput()}</>;
+  return (
+    <S.TextInput
+      error={handleEmptyInput()}
+      type="text"
+      label={label}
+      variant={variant}
+      size={size}
+      onChange={handleInputChange}
+      width={width}
+    />
+  );
 };
 
 export default TextInput;

--- a/itda-front/src/components/common/Atoms/TextInput.tsx
+++ b/itda-front/src/components/common/Atoms/TextInput.tsx
@@ -1,0 +1,67 @@
+import S from "./AtomsStyles";
+import { useState } from "react";
+
+type TTextInput = {
+  label?: string | number;
+  variant?: "outlined" | "filled" | "standard";
+  size?: "small" | "medium";
+  width?: "small" | "medium" | "large";
+};
+
+const TextInput = ({
+  label,
+  size = "small",
+  variant = "outlined",
+  width = "small",
+}: TTextInput) => {
+  const [inputState, setInputState] = useState("");
+  const handleError = () => {
+    return inputState === "" ? true : false; //왜 안되지
+  };
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputState(e.target.value);
+  };
+
+  const getCustomInput = () => {
+    switch (width) {
+      case "small": {
+        return (
+          <S.TextInput.Small
+            error={handleError()}
+            type="text"
+            label={label}
+            variant={variant}
+            size={size}
+            onChange={handleInputChange}
+          />
+        );
+      }
+      case "medium": {
+        return (
+          <S.TextInput.Medium
+            type="text"
+            label={label}
+            variant={variant}
+            size={size}
+            onChange={handleInputChange}
+          />
+        );
+      }
+      case "large": {
+        return (
+          <S.TextInput.Large
+            type="text"
+            label={label}
+            variant={variant}
+            size={size}
+            onChange={handleInputChange}
+          />
+        );
+      }
+    }
+  };
+
+  return <>{getCustomInput()}</>;
+};
+
+export default TextInput;

--- a/itda-front/src/styles/theme.ts
+++ b/itda-front/src/styles/theme.ts
@@ -16,6 +16,9 @@ const colors = {
   skyBlue: {
     normal: "#46CDCF",
   },
+  blue: {
+    extraLight: " #f2f6f8",
+  },
   navy: {
     light: "#3D84A8",
     normal: "#11698E",

--- a/itda-front/src/types/SearchBar.ts
+++ b/itda-front/src/types/SearchBar.ts
@@ -1,6 +1,6 @@
 enum ESearchCriteria {
-	PRODUCT = "PRODUCT",
-	SELLER = "SELLER",
+  PRODUCT = "PRODUCT",
+  SELLER = "SELLER",
 }
 
 export { ESearchCriteria };


### PR DESCRIPTION
## 📌 개요

Address Form Modal View를 구현합니다.

## 👩‍💻 작업 사항
- [x] RadioButton
- [x] RadioButtonWithCancel
- [x] SelectBox
- [x] TextInput -> 리팩토링 진행
- [x] 뒷 배경 어둡게 처리
- [x] Address Form Modal View 구현

## ✅ 참고 사항
![image](https://user-images.githubusercontent.com/56783350/132197679-1e37980b-7e64-452b-80a1-d2f88ecf8525.png)
- 라디오 버튼, 셀렉트 박스, input 등의 요소들을 모두 Atom으로 구현했습니다.
- RadioButtonWithCancel 는 라디오 버튼 옆에 x 버튼이 붙어있는 버튼입니다.
<img width="105" alt="스크린샷 2021-09-05 오후 6 31 56" src="https://user-images.githubusercontent.com/56783350/132122089-c56c5385-6d0c-4b2e-bbdb-cd702e918cf2.png">

- ConfirmModal은 아직 view는 안 짰는데 '삭제하시겠습니까?' 와 같은 confirm용 모달로 쓰일 재사용 Modal 컴포넌트 로 만들 예정입니다. 
- SelectBox는 option으로 들어갈 string 배열을 selectArray로 넣어주면 넣어준 옵션을 나열해줍니다.

```jsx
  const numberList = ["010", "02", "031"];
  return (
    <>
      <SelectBox selectArray={numberList} />
```
![image](https://user-images.githubusercontent.com/56783350/132122232-78b07313-f4af-4a1f-8231-72e9d07da509.png)

### TextInput Atom 사용법
- 필수 props: state, setState
- 선택 props: label(focus시 보여줄 문구), variant(input 모양), size(높이), width(너비), isRequired(필수 입력 input 여부)
- 사용 예시 

```jsx
const PhoneNumberForm = () => {
  const [inputState, setInputState] = useState(""); //임시 상태
  const numberList = ["010", "02", "031"];
  return (
    <>
      <SelectBox selectArray={numberList} />
      -
      <TextInput width={"100px"} state={inputState} setState={setInputState} />
      -
      <TextInput width={"100px"} state={inputState} setState={setInputState} />
    </>
  );
};

export default PhoneNumberForm;
```