### PR TITLE
[FEAT] 햄버거 버튼 드롭다운 구현

### DIFF
--- a/itda-front/src/components/common/CommonStyles.tsx
+++ b/itda-front/src/components/common/CommonStyles.tsx
@@ -97,7 +97,7 @@ const S = {
   },
 
   LoginDropDown: {
-    DropDownLayout: styled.div`
+    DropDownLayout: styled.ul`
       position: absolute;
       top: 100px;
       right: 25px;
@@ -106,7 +106,7 @@ const S = {
       border-radius: 10px;
     `,
 
-    DropDownMenuLayout: styled.div`
+    DropDownMenuLayout: styled.li`
       height: 35px;
       width: 100%;
       display: flex;

--- a/itda-front/src/components/common/CommonStyles.tsx
+++ b/itda-front/src/components/common/CommonStyles.tsx
@@ -26,6 +26,7 @@ const S = {
     `,
 
     HeaderLayer: styled.div`
+      position: relative;
       display: flex;
       min-width: 1200px;
       width: 80%;
@@ -91,6 +92,30 @@ const S = {
       width: auto;
       & path {
         stroke: ${({ color }) => color};
+      }
+    `,
+  },
+
+  LoginDropDown: {
+    DropDownLayout: styled.div`
+      position: absolute;
+      top: 100px;
+      right: 25px;
+      background-color: ${({ theme }) => theme.colors.white};
+      width: 130px;
+      border-radius: 10px;
+    `,
+
+    DropDownMenuLayout: styled.div`
+      height: 35px;
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 20px;
+      cursor: pointer;
+      :not(:last-child) {
+        border-bottom: 1px solid ${({ theme }) => theme.colors.gray.x_light};
       }
     `,
   },

--- a/itda-front/src/components/common/CommonStyles.tsx
+++ b/itda-front/src/components/common/CommonStyles.tsx
@@ -90,20 +90,32 @@ const S = {
     LoginButton: styled(loginIcon)`
       height: 40px;
       width: auto;
+      border-radius: 20px;
       & path {
         stroke: ${({ color }) => color};
+      }
+
+      :hover {
+        box-shadow: 0 1px 8px rgba(0, 0, 0, 0.2);
+        transition: box-shadow 0.1s ease;
       }
     `,
   },
 
   LoginDropDown: {
-    DropDownLayout: styled.ul`
+    DropDownLayout: styled.div``,
+
+    DropDownLayer: styled.ul`
       position: absolute;
       top: 100px;
       right: 25px;
       background-color: ${({ theme }) => theme.colors.white};
       width: 130px;
       border-radius: 10px;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+      opacity: ${(props) => (props.className === "dropdown active" ? 1 : 0)};
+      visibility: ${(props) =>
+        props.className === "dropdown active" ? "visible" : "hidden"}; ;
     `,
 
     DropDownMenuLayout: styled.li`
@@ -116,6 +128,10 @@ const S = {
       cursor: pointer;
       :not(:last-child) {
         border-bottom: 1px solid ${({ theme }) => theme.colors.gray.x_light};
+      }
+      :hover {
+        color: ${({ theme }) => theme.colors.navy.normal};
+        transition: color 0.2s;
       }
     `,
   },

--- a/itda-front/src/components/common/CommonStyles.tsx
+++ b/itda-front/src/components/common/CommonStyles.tsx
@@ -103,11 +103,11 @@ const S = {
   },
 
   LoginDropDown: {
-    DropDownLayout: styled.div``,
+    DropDownLayout: styled.div<{ ref: any }>``,
 
     DropDownLayer: styled.ul`
       position: absolute;
-      top: 100px;
+      top: 85px;
       right: 25px;
       background-color: ${({ theme }) => theme.colors.white};
       width: 130px;

--- a/itda-front/src/components/common/Header/Header.tsx
+++ b/itda-front/src/components/common/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import S from "../CommonStyles";
 import SideDrawer from "./SideDrawer";
@@ -9,8 +9,12 @@ type THeader = {
   isSticky?: boolean;
 };
 
+interface MutableRefObject<T> {
+  current: T;
+}
+
 const Header = ({ isSticky = false }: THeader) => {
-  const dropDownRef = useRef(null);
+  const dropDownRef = useRef<MutableRefObject<null | HTMLDivElement>>(null);
   const [isSideDrawerClicked, setIsSideDrawerClicked] = useState<
     undefined | boolean
   >(undefined);
@@ -32,6 +36,10 @@ const Header = ({ isSticky = false }: THeader) => {
     console.log("clicked!!");
     setIsDropDownActive(!isDropDownActive);
   };
+
+  useEffect(() => {
+    console.log(dropDownRef.current);
+  }, [dropDownRef]);
 
   useEffect(() => {
     const pageClickEvent = (e: MouseEvent) => {

--- a/itda-front/src/components/common/Header/Header.tsx
+++ b/itda-front/src/components/common/Header/Header.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import S from "../CommonStyles";
 import SideDrawer from "./SideDrawer";
+import LoginDropDown from "./LoginDropDown";
 import useScrollToggle from "hooks/useScrollToggle";
 
 type THeader = {
@@ -9,7 +10,10 @@ type THeader = {
 };
 
 const Header = ({ isSticky = false }: THeader) => {
-  const [isClicked, setIsClicked] = useState<undefined | boolean>(undefined);
+  const [isSideDrawerClicked, setIsSideDrawerClicked] = useState<
+    undefined | boolean
+  >(undefined);
+  const [isDropDownActive, setIsDropDownActive] = useState<boolean>(false);
   const scrollFlag = useScrollToggle(false);
 
   const checkPageName = () => {
@@ -20,7 +24,12 @@ const Header = ({ isSticky = false }: THeader) => {
   const color = isHomePage ? "#ffffff" : "#555555";
 
   const toggleSideDrawer = () => {
-    setIsClicked(true);
+    setIsSideDrawerClicked(true);
+  };
+
+  const handleLoginButtonClick = () => {
+    console.log("clicked!!");
+    setIsDropDownActive(!isDropDownActive);
   };
 
   return isSticky ? (
@@ -45,10 +54,17 @@ const Header = ({ isSticky = false }: THeader) => {
           </S.Header.LogoBlock>
           <S.Header.RightBlock>
             <S.Header.CartButton color={color} onClick={toggleSideDrawer} />
-            <S.Header.LoginButton color={color} />
+            <S.Header.LoginButton
+              color={color}
+              onClick={handleLoginButtonClick}
+            />
           </S.Header.RightBlock>
+          <LoginDropDown />
         </S.Header.HeaderLayer>
-        <SideDrawer isClicked={isClicked} setIsClicked={setIsClicked} />
+        <SideDrawer
+          isSideDrawerClicked={isSideDrawerClicked}
+          setIsSideDrawerClicked={setIsSideDrawerClicked}
+        />
       </S.Header.HeaderLayout>
     )
   ) : (
@@ -70,10 +86,17 @@ const Header = ({ isSticky = false }: THeader) => {
         </S.Header.LogoBlock>
         <S.Header.RightBlock>
           <S.Header.CartButton color={color} onClick={toggleSideDrawer} />
-          <S.Header.LoginButton color={color} />
+          <S.Header.LoginButton
+            color={color}
+            onClick={handleLoginButtonClick}
+          />
         </S.Header.RightBlock>
+        <LoginDropDown />
       </S.Header.HeaderLayer>
-      <SideDrawer isClicked={isClicked} setIsClicked={setIsClicked} />
+      <SideDrawer
+        isSideDrawerClicked={isSideDrawerClicked}
+        setIsSideDrawerClicked={setIsSideDrawerClicked}
+      />
     </S.Header.HeaderLayout>
   );
 };

--- a/itda-front/src/components/common/Header/Header.tsx
+++ b/itda-front/src/components/common/Header/Header.tsx
@@ -33,7 +33,6 @@ const Header = ({ isSticky = false }: THeader) => {
   };
 
   const handleLoginButtonClick = () => {
-    console.log("clicked!!");
     setIsDropDownActive(!isDropDownActive);
   };
 
@@ -43,12 +42,7 @@ const Header = ({ isSticky = false }: THeader) => {
 
   useEffect(() => {
     const pageClickEvent = (e: MouseEvent) => {
-      console.log("eventtarget", e.target);
-      console.log("dropDownRef.current", dropDownRef.current);
-      if (
-        dropDownRef.current !== null //왜 자꾸 null이 나올까? null이 아니라 DOM 요소가 나와야 비교를 하는데 null이 자꾸 뜸.
-        // && dropDownRef.current.contains(e.target)
-      ) {
+      if (dropDownRef.current !== null) {
         setIsDropDownActive(!isDropDownActive);
       }
     };

--- a/itda-front/src/components/common/Header/Header.tsx
+++ b/itda-front/src/components/common/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import S from "../CommonStyles";
 import SideDrawer from "./SideDrawer";
@@ -10,6 +10,7 @@ type THeader = {
 };
 
 const Header = ({ isSticky = false }: THeader) => {
+  const dropDownRef = useRef(null);
   const [isSideDrawerClicked, setIsSideDrawerClicked] = useState<
     undefined | boolean
   >(undefined);
@@ -31,6 +32,27 @@ const Header = ({ isSticky = false }: THeader) => {
     console.log("clicked!!");
     setIsDropDownActive(!isDropDownActive);
   };
+
+  useEffect(() => {
+    const pageClickEvent = (e: MouseEvent) => {
+      console.log("eventtarget", e.target);
+      console.log("dropDownRef.current", dropDownRef.current);
+      if (
+        dropDownRef.current !== null //왜 자꾸 null이 나올까? null이 아니라 DOM 요소가 나와야 비교를 하는데 null이 자꾸 뜸.
+        // && dropDownRef.current.contains(e.target)
+      ) {
+        setIsDropDownActive(!isDropDownActive);
+      }
+    };
+
+    if (isDropDownActive) {
+      window.addEventListener("click", pageClickEvent);
+    }
+
+    return () => {
+      window.removeEventListener("click", pageClickEvent);
+    };
+  }, [isDropDownActive]);
 
   return isSticky ? (
     scrollFlag ? (
@@ -59,7 +81,10 @@ const Header = ({ isSticky = false }: THeader) => {
               onClick={handleLoginButtonClick}
             />
           </S.Header.RightBlock>
-          <LoginDropDown />
+          <LoginDropDown
+            ref={dropDownRef}
+            className={`dropdown ${isDropDownActive ? "active" : "inactive"}`}
+          />
         </S.Header.HeaderLayer>
         <SideDrawer
           isSideDrawerClicked={isSideDrawerClicked}
@@ -91,7 +116,10 @@ const Header = ({ isSticky = false }: THeader) => {
             onClick={handleLoginButtonClick}
           />
         </S.Header.RightBlock>
-        <LoginDropDown />
+        <LoginDropDown
+          ref={dropDownRef}
+          className={`dropdown ${isDropDownActive ? "active" : "inactive"}`}
+        />
       </S.Header.HeaderLayer>
       <SideDrawer
         isSideDrawerClicked={isSideDrawerClicked}

--- a/itda-front/src/components/common/Header/LoginDropDown.tsx
+++ b/itda-front/src/components/common/Header/LoginDropDown.tsx
@@ -1,14 +1,22 @@
+import { MutableRefObject } from "react";
 import S from "../CommonStyles";
 
-const LoginDropDown = () => {
+type TLoginDropDownProp = {
+  ref?: MutableRefObject<null> | undefined;
+  className: string;
+};
+
+const LoginDropDown = ({ ref, className }: TLoginDropDownProp) => {
   const loggedInMenu = ["마이페이지", "로그아웃"];
   const loggedOutMenu = ["로그인", "회원가입"];
 
   return (
-    <S.LoginDropDown.DropDownLayout>
-      {loggedInMenu.map((menuName: string) => (
-        <LoginDropDownMenu name={menuName} />
-      ))}
+    <S.LoginDropDown.DropDownLayout ref={ref}>
+      <S.LoginDropDown.DropDownLayer className={className}>
+        {loggedInMenu.map((menuName: string) => (
+          <LoginDropDownMenu name={menuName} />
+        ))}
+      </S.LoginDropDown.DropDownLayer>
     </S.LoginDropDown.DropDownLayout>
   );
 };

--- a/itda-front/src/components/common/Header/LoginDropDown.tsx
+++ b/itda-front/src/components/common/Header/LoginDropDown.tsx
@@ -20,7 +20,10 @@ type TLoginDropDownMenuProp = {
 const LoginDropDownMenu = ({ name }: TLoginDropDownMenuProp) => {
   return (
     <S.LoginDropDown.DropDownMenuLayout>
-      {name}
+      {name === "마이페이지" && <a href="/myPage">{name}</a>}
+      {name === "로그아웃" && <a href="/login">{name}</a>}
+      {name === "로그인" && <a href="/login">{name}</a>}
+      {name === "회원가입" && <a href="/signUp">{name}</a>}
     </S.LoginDropDown.DropDownMenuLayout>
   );
 };

--- a/itda-front/src/components/common/Header/LoginDropDown.tsx
+++ b/itda-front/src/components/common/Header/LoginDropDown.tsx
@@ -1,21 +1,30 @@
 import { MutableRefObject } from "react";
+import { useRecoilState } from "recoil";
+import { isLoggedIn } from "stores/LoginAtoms";
 import S from "../CommonStyles";
 
 type TLoginDropDownProp = {
-  ref?: MutableRefObject<null> | undefined;
+  // ref?: React.MutableRefObject<null | HTMLDivElement>;
+  ref: any;
   className: string;
 };
 
 const LoginDropDown = ({ ref, className }: TLoginDropDownProp) => {
+  const loggedInByUser = useRecoilState(isLoggedIn);
+  console.log(loggedInByUser);
   const loggedInMenu = ["마이페이지", "로그아웃"];
   const loggedOutMenu = ["로그인", "회원가입"];
 
   return (
     <S.LoginDropDown.DropDownLayout ref={ref}>
       <S.LoginDropDown.DropDownLayer className={className}>
-        {loggedInMenu.map((menuName: string) => (
-          <LoginDropDownMenu name={menuName} />
-        ))}
+        {loggedInByUser[0]
+          ? loggedInMenu.map((menuName: string) => (
+              <LoginDropDownMenu name={menuName} />
+            ))
+          : loggedOutMenu.map((menuName: string) => (
+              <LoginDropDownMenu name={menuName} />
+            ))}
       </S.LoginDropDown.DropDownLayer>
     </S.LoginDropDown.DropDownLayout>
   );

--- a/itda-front/src/components/common/Header/LoginDropDown.tsx
+++ b/itda-front/src/components/common/Header/LoginDropDown.tsx
@@ -1,4 +1,4 @@
-import { MutableRefObject } from "react";
+import React, { MutableRefObject } from "react";
 import { useRecoilState } from "recoil";
 import { isLoggedIn } from "stores/LoginAtoms";
 import S from "../CommonStyles";
@@ -9,26 +9,27 @@ type TLoginDropDownProp = {
   className: string;
 };
 
-const LoginDropDown = ({ ref, className }: TLoginDropDownProp) => {
-  const loggedInByUser = useRecoilState(isLoggedIn);
-  console.log(loggedInByUser);
-  const loggedInMenu = ["마이페이지", "로그아웃"];
-  const loggedOutMenu = ["로그인", "회원가입"];
+const LoginDropDown = React.forwardRef(
+  ({ className }: TLoginDropDownProp, ref) => {
+    const loggedInByUser = useRecoilState(isLoggedIn);
+    const loggedInMenu = ["마이페이지", "로그아웃"];
+    const loggedOutMenu = ["로그인", "회원가입"];
 
-  return (
-    <S.LoginDropDown.DropDownLayout ref={ref}>
-      <S.LoginDropDown.DropDownLayer className={className}>
-        {loggedInByUser[0]
-          ? loggedInMenu.map((menuName: string) => (
-              <LoginDropDownMenu name={menuName} />
-            ))
-          : loggedOutMenu.map((menuName: string) => (
-              <LoginDropDownMenu name={menuName} />
-            ))}
-      </S.LoginDropDown.DropDownLayer>
-    </S.LoginDropDown.DropDownLayout>
-  );
-};
+    return (
+      <S.LoginDropDown.DropDownLayout ref={ref}>
+        <S.LoginDropDown.DropDownLayer className={className}>
+          {loggedInByUser[0]
+            ? loggedInMenu.map((menuName: string) => (
+                <LoginDropDownMenu name={menuName} />
+              ))
+            : loggedOutMenu.map((menuName: string) => (
+                <LoginDropDownMenu name={menuName} />
+              ))}
+        </S.LoginDropDown.DropDownLayer>
+      </S.LoginDropDown.DropDownLayout>
+    );
+  }
+);
 
 type TLoginDropDownMenuProp = {
   name: string;

--- a/itda-front/src/components/common/Header/LoginDropDown.tsx
+++ b/itda-front/src/components/common/Header/LoginDropDown.tsx
@@ -1,0 +1,28 @@
+import S from "../CommonStyles";
+
+const LoginDropDown = () => {
+  const loggedInMenu = ["마이페이지", "로그아웃"];
+  const loggedOutMenu = ["로그인", "회원가입"];
+
+  return (
+    <S.LoginDropDown.DropDownLayout>
+      {loggedInMenu.map((menuName: string) => (
+        <LoginDropDownMenu name={menuName} />
+      ))}
+    </S.LoginDropDown.DropDownLayout>
+  );
+};
+
+type TLoginDropDownMenuProp = {
+  name: string;
+};
+
+const LoginDropDownMenu = ({ name }: TLoginDropDownMenuProp) => {
+  return (
+    <S.LoginDropDown.DropDownMenuLayout>
+      {name}
+    </S.LoginDropDown.DropDownMenuLayout>
+  );
+};
+
+export default LoginDropDown;

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -8,11 +8,14 @@ import { ICartProduct, ISendingCartProduct } from "types/CartTypes";
 import { GETCartData } from "util/mock/GETCartData";
 
 type TSideDrawer = {
-  isClicked: undefined | boolean;
-  setIsClicked: (value: boolean) => void;
+  isSideDrawerClicked: undefined | boolean;
+  setIsSideDrawerClicked: (value: boolean) => void;
 };
 
-const SideDrawer = ({ isClicked, setIsClicked }: TSideDrawer) => {
+const SideDrawer = ({
+  isSideDrawerClicked,
+  setIsSideDrawerClicked,
+}: TSideDrawer) => {
   const MockData = GETCartData.data.detail;
   const [cartProductList, setCartProductList] = useRecoilState(cartProductData);
   const [cartProductsCount, setCartProductsCount] = useState<
@@ -21,7 +24,7 @@ const SideDrawer = ({ isClicked, setIsClicked }: TSideDrawer) => {
   const [cartTotalPrice, setCartTotalPrice] = useState(0);
 
   const handleCloseButtonClick = () => {
-    setIsClicked(false);
+    setIsSideDrawerClicked(false);
   };
 
   const removeItem = (id: number) => {
@@ -63,11 +66,11 @@ const SideDrawer = ({ isClicked, setIsClicked }: TSideDrawer) => {
   }, [cartProductsCount]);
 
   return (
-    <S.SideDrawer.DrawerLayout isClicked={isClicked}>
+    <S.SideDrawer.DrawerLayout isClicked={isSideDrawerClicked}>
       <S.SideDrawer.DrawerHeaderLayer>
         <div>담은 상품 목록</div>
         <S.SideDrawer.DrawerCardCloseButton
-          isClicked={isClicked}
+          isClicked={isSideDrawerClicked}
           onClick={handleCloseButtonClick}
         >
           <S.SideDrawer.DrawerCloseIcon />

--- a/itda-front/src/stores/LoginAtoms.ts
+++ b/itda-front/src/stores/LoginAtoms.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const isLoggedIn = atom({
+  key: "isLoggedIn",
+  default: false,
+});

--- a/itda-front/src/stores/LoginAtoms.ts
+++ b/itda-front/src/stores/LoginAtoms.ts
@@ -2,5 +2,5 @@ import { atom } from "recoil";
 
 export const isLoggedIn = atom({
   key: "isLoggedIn",
-  default: false,
+  default: true,
 });


### PR DESCRIPTION
## 📌 개요
- Resolve #133 
햄버거 버튼 클릭 시 노출되는 드롭다운 구현하기
드롭다운은 경우에 따라 메뉴가 다르게 보여져야 한다:

1) 로그인이 안되어 있을 때: 로그인 & 회원가입
2) 로그인이 되어있을 때: 마이페이지 & 로그아웃

## 👩‍💻 작업 사항

- [x] 드롭다운 UI 만들기
- [x] 클릭이벤트로 드롭다운 노출 로직 구현하기
- [x] 드롭다운 사라지는 로직 구현하기
- [x] 로그인 상태에 따라 메뉴를 다르게 보여주는 로직 구현하기 + 전역 로그인상태 추가하기 
- [x] 클릭시 해당 페이지로 이동하는 라우팅 기능 구현하기

## ✅ 참고 사항

- 사용자의 로그인 여부를 전역상태로 관리할 수 있도록 로그인 관련 atom을 추가했어요~! (없는 것 같아서 만들었는데 혹시 중복이면 알려주세요🙏🏻)

( 참고자료: https://driip.me/7126d5d5-1937-44a8-98ed-f9065a7c35b5)
![image](https://user-images.githubusercontent.com/65105537/132429949-cdacb626-feb9-4be7-afc4-a24429289ff9.png)