### PR TITLE
[FEAT] 판매자정보 수정 페이지 구현

### DIFF
--- a/itda-front/src/components/MyPage/MyInfoEditAfter.tsx
+++ b/itda-front/src/components/MyPage/MyInfoEditAfter.tsx
@@ -3,7 +3,7 @@ import S from "./MyPageStyles";
 const MyInfoEditAfter = () => {
   return (
     <S.MyInfoAfter.Layout>
-      <S.MyInfoAfter.HeaderLayer>개인정보 수정</S.MyInfoAfter.HeaderLayer>
+      <S.MyInfoAfter.HeaderLayer>기본 정보 수정</S.MyInfoAfter.HeaderLayer>
       <S.MyInfoAfter.FormLayer>
         <S.MyInfoAfter.FormInputsLayer>
           <S.MyInfoAfter.CurrentPasswordBlock>

--- a/itda-front/src/components/MyPage/MyPage.tsx
+++ b/itda-front/src/components/MyPage/MyPage.tsx
@@ -6,11 +6,14 @@ import MyReview from "components/MyPage/MyReview";
 import MyPageOrderList from "./MyPageOrderList";
 import MyInfoEditBefore from "./MyInfoEditBefore";
 import MyInfoEditAfter from "./MyInfoEditAfter";
+import { SellerInfoEdit } from "./SellerPage";
 
 const MyPage = () => {
   const [currentSelectedTab, setCurrentSelectedTab] = useState("주문 내역");
-  //임시로 만든 로그인 상태
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  //임시로 만든 로그인 상태: true => 기본정보수정 페이지, 판매자 페이지 보여짐
+  const [isLoggedIn, setIsLoggedIn] = useState(true);
+  //임시로 만든 판매자 식별 상태
+  const [isSeller, setIsSeller] = useState(true);
 
   const handleTabClick = (tabName: string) => {
     setCurrentSelectedTab(tabName);
@@ -35,7 +38,13 @@ const MyPage = () => {
               {currentSelectedTab === "상품 후기" && <MyReview />}
               {currentSelectedTab === "잇다톡"}
               {currentSelectedTab === "개인 정보 수정" &&
-                (!isLoggedIn ? <MyInfoEditBefore /> : <MyInfoEditAfter />)}
+                (!isLoggedIn ? (
+                  <MyInfoEditBefore />
+                ) : isSeller ? (
+                  <SellerInfoEdit />
+                ) : (
+                  <MyInfoEditAfter />
+                ))}
             </S.MyPage.ContentLayer>
           </S.MyPage.ContentLayout>
         </S.MyPage.MainLayout>

--- a/itda-front/src/components/MyPage/MyPage.tsx
+++ b/itda-front/src/components/MyPage/MyPage.tsx
@@ -11,9 +11,9 @@ import { SellerInfoEdit } from "./SellerPage";
 const MyPage = () => {
   const [currentSelectedTab, setCurrentSelectedTab] = useState("주문 내역");
   //임시로 만든 로그인 상태: true => 기본정보수정 페이지, 판매자 페이지 보여짐
-  const [isLoggedIn, setIsLoggedIn] = useState(true);
-  //임시로 만든 판매자 식별 상태
-  const [isSeller, setIsSeller] = useState(true);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  //임시로 만든 판매자 식별 상태 => seller화면 보기: true
+  const [isSeller, setIsSeller] = useState(false);
 
   const handleTabClick = (tabName: string) => {
     setCurrentSelectedTab(tabName);

--- a/itda-front/src/components/MyPage/MyPageStyles.ts
+++ b/itda-front/src/components/MyPage/MyPageStyles.ts
@@ -161,6 +161,8 @@ const S = {
     `,
 
     HeaderLayer: styled.div`
+      font-family: "Gowun Batang", sans-serif;
+      color: ${({ theme }) => theme.colors.gray.normal};
       font-size: ${({ theme }) => theme.fontSizes.titleSize};
       font-weight: bold;
       margin-bottom: 1.5rem;
@@ -229,6 +231,8 @@ const S = {
     `,
 
     HeaderLayer: styled.div`
+      font-family: "Gowun Batang", sans-serif;
+      color: ${({ theme }) => theme.colors.gray.normal};
       font-size: ${({ theme }) => theme.fontSizes.titleSize};
       font-weight: bold;
       margin-bottom: 1.5rem;

--- a/itda-front/src/components/MyPage/MyPageStyles.ts
+++ b/itda-front/src/components/MyPage/MyPageStyles.ts
@@ -76,6 +76,11 @@ const S = {
       font-weight: ${(props) =>
         props.currentSelectedTab === props.category ? "900" : "200"};
       transition: background-color 0.3s;
+
+      &:hover {
+        color: ${({ theme }) => theme.colors.navy.normal};
+        transition: color 0.3s;
+      }
     `,
   },
 

--- a/itda-front/src/components/MyPage/MyPageTab.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab.tsx
@@ -11,11 +11,16 @@ const MyPageTab = ({
   currentSelectedTab,
   handleTabClick,
 }: IMyPageTabProps) => {
+  const handleMouseEnter = () => {
+    // todo: 탭에 마우스가 들어왔을 때 탭 이름이 "개인정보수정"이라면, 하위 탭의 "기본정보"와 "판매자정보"를 보여주기
+  };
+
   return (
     <S.MyPageTab.Layout
       category={category}
       currentSelectedTab={currentSelectedTab}
       onClick={() => handleTabClick(category)}
+      onMouseEnter={() => handleMouseEnter()}
     >
       {category}
     </S.MyPageTab.Layout>

--- a/itda-front/src/components/MyPage/SellerPage/ProfileImageUploader.tsx
+++ b/itda-front/src/components/MyPage/SellerPage/ProfileImageUploader.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { useRecoilState } from "recoil";
+import { sellerProfilePreviewImage } from "stores/SellerInfoAtoms";
+import S from "./SellerInfoStyles";
+
+const ProfileImageUploader = () => {
+  const [previewImage, setPreviewImage] = useRecoilState(
+    sellerProfilePreviewImage
+  );
+
+  const handlePreviewChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
+
+    const reader = new FileReader();
+    let file = e.target.files[0];
+
+    reader.onload = () => {
+      if (reader.readyState === 2) {
+        setPreviewImage({ file: file, previewURL: reader.result });
+      }
+    };
+    reader.readAsDataURL(e.target.files[0]);
+  };
+
+  return (
+    <S.ProfileImageUploader.Layout>
+      <S.ProfileImageUploader.ImageHolder>
+        {!previewImage.previewURL ? (
+          <S.ProfileImageUploader.PreviewImageText>
+            프로필 이미지를 설정해주세요.
+          </S.ProfileImageUploader.PreviewImageText>
+        ) : (
+          <S.ProfileImageUploader.PreviewImage
+            src={previewImage.previewURL}
+            alt="프로필 이미지"
+          />
+        )}
+      </S.ProfileImageUploader.ImageHolder>
+      <S.ProfileImageUploader.ImageUploadInput
+        type="file"
+        accept="image/*"
+        onChange={handlePreviewChange}
+      />
+    </S.ProfileImageUploader.Layout>
+  );
+};
+
+export default ProfileImageUploader;

--- a/itda-front/src/components/MyPage/SellerPage/ProfileTextForm.tsx
+++ b/itda-front/src/components/MyPage/SellerPage/ProfileTextForm.tsx
@@ -1,0 +1,28 @@
+import S from "./SellerInfoStyles";
+import theme from "styles/theme";
+import ColorButton from "components/common/Atoms/ColorButton";
+
+const ProfileTextForm = () => {
+  return (
+    <S.ProfileTextForm.Layout>
+      <S.ProfileTextForm.ProfileTextbox
+        id="outlined-multiline-static"
+        multiline
+        rows={10}
+        placeholder="판매자님을 소개하는 한마디를 적어주세요."
+        variant="outlined"
+      />
+      <S.ProfileTextForm.ButtonLayer>
+        <ColorButton
+          width="200px"
+          height="40px"
+          baseColor={theme.colors.navy.normal}
+        >
+          확인
+        </ColorButton>
+      </S.ProfileTextForm.ButtonLayer>
+    </S.ProfileTextForm.Layout>
+  );
+};
+
+export default ProfileTextForm;

--- a/itda-front/src/components/MyPage/SellerPage/ProfileTextForm.tsx
+++ b/itda-front/src/components/MyPage/SellerPage/ProfileTextForm.tsx
@@ -1,6 +1,6 @@
 import { useRecoilState } from "recoil";
 import { sellerProfileText } from "stores/SellerInfoAtoms";
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import S from "./SellerInfoStyles";
 import theme from "styles/theme";
 import ColorButton from "components/common/Atoms/ColorButton";
@@ -10,7 +10,17 @@ const ProfileTextForm = () => {
   const [profileText, setProfileText] = useRecoilState(sellerProfileText);
   const [isEditMode, setIsEditMode] = useState(false);
 
-  const handleConfirmButtonClick = () => {};
+  const updateProfileText = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    console.log(e.target.value);
+    const inputText = e.target.value;
+    setProfileText({ text: inputText });
+  };
+
+  const handleConfirmButtonClick = () => {
+    setIsEditMode(false);
+  };
 
   const handleCancelButtonClick = () => {
     setIsEditMode(false);
@@ -28,10 +38,12 @@ const ProfileTextForm = () => {
         <>
           <S.ProfileTextForm.ProfileTextbox
             id="outlined-multiline-static"
+            value={profileText.text}
             multiline
             rows={10}
             placeholder="판매자님을 소개하는 한마디를 적어주세요."
             variant="outlined"
+            onChange={(e) => updateProfileText(e)}
           />
           <S.ProfileTextForm.ButtonLayer>
             <ColorButton

--- a/itda-front/src/components/MyPage/SellerPage/ProfileTextForm.tsx
+++ b/itda-front/src/components/MyPage/SellerPage/ProfileTextForm.tsx
@@ -1,33 +1,74 @@
+import { useRecoilState } from "recoil";
+import { sellerProfileText } from "stores/SellerInfoAtoms";
+import { useState, useEffect } from "react";
 import S from "./SellerInfoStyles";
 import theme from "styles/theme";
 import ColorButton from "components/common/Atoms/ColorButton";
 
 const ProfileTextForm = () => {
+  // 서버에서 유저정보 가져올 때 가져올 것!
+  const [profileText, setProfileText] = useRecoilState(sellerProfileText);
+  const [isEditMode, setIsEditMode] = useState(false);
+
+  const handleConfirmButtonClick = () => {};
+
+  const handleCancelButtonClick = () => {
+    setIsEditMode(false);
+  };
+
+  const handleReviseButtonClick = () => {
+    setIsEditMode(true);
+  };
+
+  useEffect(() => {}, [isEditMode]);
+
   return (
     <S.ProfileTextForm.Layout>
-      <S.ProfileTextForm.ProfileTextbox
-        id="outlined-multiline-static"
-        multiline
-        rows={10}
-        placeholder="판매자님을 소개하는 한마디를 적어주세요."
-        variant="outlined"
-      />
-      <S.ProfileTextForm.ButtonLayer>
-        <ColorButton
-          width="200px"
-          height="40px"
-          baseColor={theme.colors.gray.light}
-        >
-          취소
-        </ColorButton>
-        <ColorButton
-          width="200px"
-          height="40px"
-          baseColor={theme.colors.navy.normal}
-        >
-          확인
-        </ColorButton>
-      </S.ProfileTextForm.ButtonLayer>
+      {isEditMode ? (
+        <>
+          <S.ProfileTextForm.ProfileTextbox
+            id="outlined-multiline-static"
+            multiline
+            rows={10}
+            placeholder="판매자님을 소개하는 한마디를 적어주세요."
+            variant="outlined"
+          />
+          <S.ProfileTextForm.ButtonLayer>
+            <ColorButton
+              width="200px"
+              height="40px"
+              baseColor={theme.colors.gray.light}
+              onClickButton={handleCancelButtonClick}
+            >
+              취소
+            </ColorButton>
+            <ColorButton
+              width="200px"
+              height="40px"
+              baseColor={theme.colors.navy.normal}
+              onClickButton={handleConfirmButtonClick}
+            >
+              확인
+            </ColorButton>
+          </S.ProfileTextForm.ButtonLayer>
+        </>
+      ) : (
+        <>
+          <S.ProfileTextForm.ProfileText>
+            {`"${profileText.text}"`}
+          </S.ProfileTextForm.ProfileText>
+          <S.ProfileTextForm.ButtonLayer>
+            <ColorButton
+              width="200px"
+              height="40px"
+              baseColor={theme.colors.navy.normal}
+              onClickButton={handleReviseButtonClick}
+            >
+              수정
+            </ColorButton>
+          </S.ProfileTextForm.ButtonLayer>
+        </>
+      )}
     </S.ProfileTextForm.Layout>
   );
 };

--- a/itda-front/src/components/MyPage/SellerPage/ProfileTextForm.tsx
+++ b/itda-front/src/components/MyPage/SellerPage/ProfileTextForm.tsx
@@ -16,6 +16,13 @@ const ProfileTextForm = () => {
         <ColorButton
           width="200px"
           height="40px"
+          baseColor={theme.colors.gray.light}
+        >
+          취소
+        </ColorButton>
+        <ColorButton
+          width="200px"
+          height="40px"
           baseColor={theme.colors.navy.normal}
         >
           확인

--- a/itda-front/src/components/MyPage/SellerPage/SellerInfoEdit.tsx
+++ b/itda-front/src/components/MyPage/SellerPage/SellerInfoEdit.tsx
@@ -1,0 +1,20 @@
+import S from "./SellerInfoStyles";
+import ProfileImageUploader from "./ProfileImageUploader";
+
+const SellerInfoEdit = () => {
+  return (
+    <S.SellerInfoEdit.Layout>
+      <S.SellerInfoEdit.HeaderLayer>
+        판매자 정보 수정
+      </S.SellerInfoEdit.HeaderLayer>
+      <S.SellerInfoEdit.FormLayer>
+        <S.SellerInfoEdit.ProfileImageBlock>
+          <ProfileImageUploader />
+        </S.SellerInfoEdit.ProfileImageBlock>
+        <S.SellerInfoEdit.DescriptionBlock></S.SellerInfoEdit.DescriptionBlock>
+      </S.SellerInfoEdit.FormLayer>
+    </S.SellerInfoEdit.Layout>
+  );
+};
+
+export default SellerInfoEdit;

--- a/itda-front/src/components/MyPage/SellerPage/SellerInfoEdit.tsx
+++ b/itda-front/src/components/MyPage/SellerPage/SellerInfoEdit.tsx
@@ -1,5 +1,6 @@
 import S from "./SellerInfoStyles";
 import ProfileImageUploader from "./ProfileImageUploader";
+import ProfileTextForm from "./ProfileTextForm";
 
 const SellerInfoEdit = () => {
   return (
@@ -11,7 +12,9 @@ const SellerInfoEdit = () => {
         <S.SellerInfoEdit.ProfileImageBlock>
           <ProfileImageUploader />
         </S.SellerInfoEdit.ProfileImageBlock>
-        <S.SellerInfoEdit.DescriptionBlock></S.SellerInfoEdit.DescriptionBlock>
+        <S.SellerInfoEdit.DescriptionBlock>
+          <ProfileTextForm />
+        </S.SellerInfoEdit.DescriptionBlock>
       </S.SellerInfoEdit.FormLayer>
     </S.SellerInfoEdit.Layout>
   );

--- a/itda-front/src/components/MyPage/SellerPage/SellerInfoStyles.ts
+++ b/itda-front/src/components/MyPage/SellerPage/SellerInfoStyles.ts
@@ -96,6 +96,15 @@ const S = {
         margin: 0.5rem;
       }
     `,
+
+    ProfileText: styled.p`
+      width: 500px;
+      height: 230px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 1rem;
+    `,
   },
 };
 

--- a/itda-front/src/components/MyPage/SellerPage/SellerInfoStyles.ts
+++ b/itda-front/src/components/MyPage/SellerPage/SellerInfoStyles.ts
@@ -28,14 +28,14 @@ const S = {
     `,
 
     ProfileImageBlock: styled.div`
-      width: 30%;
+      width: 25%;
       height: 500px;
       display: flex;
       align-items: center;
     `,
 
     DescriptionBlock: styled.div`
-      width: 50%;
+      width: 60%;
       height: 500px;
       display: flex;
       align-items: center;
@@ -93,6 +93,7 @@ const S = {
       padding: 1rem;
       & > button {
         font-weight: 350;
+        margin: 0.5rem;
       }
     `,
   },

--- a/itda-front/src/components/MyPage/SellerPage/SellerInfoStyles.ts
+++ b/itda-front/src/components/MyPage/SellerPage/SellerInfoStyles.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import TextField from "@material-ui/core/TextField";
 
 //판매자 정보 수정 페이지와 등록상품조회 페이지의 스타일을 관리합니다.
 const S = {
@@ -27,13 +28,17 @@ const S = {
     `,
 
     ProfileImageBlock: styled.div`
-      width: 50%;
-      border: 1px solid red;
+      width: 30%;
+      height: 500px;
+      display: flex;
+      align-items: center;
     `,
 
     DescriptionBlock: styled.div`
       width: 50%;
-      border: 1px solid green;
+      height: 500px;
+      display: flex;
+      align-items: center;
     `,
   },
 
@@ -46,25 +51,49 @@ const S = {
     `,
 
     ImageHolder: styled.div`
-      border: 1px solid ${({ theme }) => theme.colors.gray.normal};
-      width: 300px;
-      height: 350px;
+      width: 250px;
+      height: 250px;
       display: flex;
       align-items: center;
       justify-content: center;
+      border: 1px solid ${({ theme }) => theme.colors.gray.normal};
+      border-radius: 200px;
     `,
 
     PreviewImageText: styled.p`
       font-size: 1rem;
+      color: ${({ theme }) => theme.colors.gray.normal};
     `,
 
     PreviewImage: styled.img`
       width: 100%;
       height: 100%;
+      border-radius: 200px;
     `,
 
     ImageUploadInput: styled.input`
       margin: 1rem;
+    `,
+  },
+
+  ProfileTextForm: {
+    Layout: styled.div`
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    `,
+
+    ProfileTextbox: styled(TextField)`
+      width: 500px;
+      margin: 0 auto;
+    `,
+
+    ButtonLayer: styled.div`
+      padding: 1rem;
+      & > button {
+        font-weight: 350;
+      }
     `,
   },
 };

--- a/itda-front/src/components/MyPage/SellerPage/SellerInfoStyles.ts
+++ b/itda-front/src/components/MyPage/SellerPage/SellerInfoStyles.ts
@@ -1,0 +1,72 @@
+import styled from "styled-components";
+
+//판매자 정보 수정 페이지와 등록상품조회 페이지의 스타일을 관리합니다.
+const S = {
+  SellerInfoEdit: {
+    Layout: styled.div`
+      min-width: 1024px;
+      width: 90%;
+      height: 100%;
+      margin: 0 auto;
+    `,
+
+    HeaderLayer: styled.div`
+      font-family: "Gowun Batang", sans-serif;
+      color: ${({ theme }) => theme.colors.gray.normal};
+      font-size: ${({ theme }) => theme.fontSizes.titleSize};
+      font-weight: bold;
+      margin-bottom: 1.5rem;
+      height: 5rem;
+    `,
+
+    FormLayer: styled.div`
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: flex-end;
+    `,
+
+    ProfileImageBlock: styled.div`
+      width: 50%;
+      border: 1px solid red;
+    `,
+
+    DescriptionBlock: styled.div`
+      width: 50%;
+      border: 1px solid green;
+    `,
+  },
+
+  ProfileImageUploader: {
+    Layout: styled.div`
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    `,
+
+    ImageHolder: styled.div`
+      border: 1px solid ${({ theme }) => theme.colors.gray.normal};
+      width: 300px;
+      height: 350px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    `,
+
+    PreviewImageText: styled.p`
+      font-size: 1rem;
+    `,
+
+    PreviewImage: styled.img`
+      width: 100%;
+      height: 100%;
+    `,
+
+    ImageUploadInput: styled.input`
+      margin: 1rem;
+    `,
+  },
+};
+
+export default S;

--- a/itda-front/src/components/MyPage/SellerPage/index.ts
+++ b/itda-front/src/components/MyPage/SellerPage/index.ts
@@ -1,0 +1,1 @@
+export { default as SellerInfoEdit } from "./SellerInfoEdit";

--- a/itda-front/src/components/common/Header/Header.tsx
+++ b/itda-front/src/components/common/Header/Header.tsx
@@ -37,11 +37,8 @@ const Header = ({ isSticky = false }: THeader) => {
   };
 
   useEffect(() => {
-    console.log(dropDownRef.current);
-  }, [dropDownRef]);
-
-  useEffect(() => {
     const pageClickEvent = (e: MouseEvent) => {
+      console.log(dropDownRef.current);
       if (dropDownRef.current !== null) {
         setIsDropDownActive(!isDropDownActive);
       }

--- a/itda-front/src/stores/SellerInfoAtoms.ts
+++ b/itda-front/src/stores/SellerInfoAtoms.ts
@@ -10,3 +10,10 @@ export const sellerProfilePreviewImage = atom<{
     previewURL: null,
   },
 });
+
+export const sellerProfileText = atom<{ text: string }>({
+  key: "sellerProfileText",
+  default: {
+    text: "",
+  },
+});

--- a/itda-front/src/stores/SellerInfoAtoms.ts
+++ b/itda-front/src/stores/SellerInfoAtoms.ts
@@ -14,6 +14,6 @@ export const sellerProfilePreviewImage = atom<{
 export const sellerProfileText = atom<{ text: string }>({
   key: "sellerProfileText",
   default: {
-    text: "",
+    text: "마음을 담아 재배합니다.",
   },
 });

--- a/itda-front/src/stores/SellerInfoAtoms.ts
+++ b/itda-front/src/stores/SellerInfoAtoms.ts
@@ -1,0 +1,12 @@
+import { atom } from "recoil";
+
+export const sellerProfilePreviewImage = atom<{
+  file: any;
+  previewURL: any;
+}>({
+  key: "sellerProfilePreviewImage",
+  default: {
+    file: null,
+    previewURL: null,
+  },
+});


### PR DESCRIPTION
## 📌 개요
- Close #144 
판매자용 정보(소개글, 프로필 사진)를 수정할 수 있는 페이지 구현 완료.

## 👩‍💻 작업 사항

- [x] 판매자정보 수정 페이지용 컴포넌트 생성
- [x] 이미지 첨부파일 업로드 input 추가
- [x] 판매자 소개문구 input 추가

## ✅ 참고 사항
`MyPage.tsx`에서 `isLoggedIn`과 `isSeller`를 true로 해야 확인가능.
![image](https://user-images.githubusercontent.com/65105537/133374641-30eb1742-ff66-4add-9291-2454257fa36f.png)
![image](https://user-images.githubusercontent.com/65105537/133374665-7209874f-bd81-48ea-a350-0a46adca9bc0.png)

