### PR TITLE
[FEAT] 판매자용 MyPage 등록상품조회 tab 추가 + 판매자용 subTab 추가

### DIFF
--- a/itda-front/src/components/MyPage/MyPage.tsx
+++ b/itda-front/src/components/MyPage/MyPage.tsx
@@ -10,6 +10,7 @@ import { SellerInfoEdit } from "./SellerPage";
 
 const MyPage = () => {
   const [currentSelectedTab, setCurrentSelectedTab] = useState("주문 내역");
+  console.log(currentSelectedTab);
   //임시로 만든 로그인 상태: true => 기본정보수정 페이지, 판매자 페이지 보여짐
   const [isLoggedIn, setIsLoggedIn] = useState(true);
   //임시로 만든 판매자 식별 상태 => 판매자용 화면/탭 보기: true
@@ -34,6 +35,7 @@ const MyPage = () => {
               isSubtabVisible={isSubtabVisible}
               setIsSubtabVisible={setIsSubtabVisible}
               currentSelectedTab={currentSelectedTab}
+              setCurrentSelectedTab={setCurrentSelectedTab}
               handleTabClick={handleTabClick}
             />
           </S.MyPage.SideTabLayout>
@@ -42,14 +44,9 @@ const MyPage = () => {
               {currentSelectedTab === "주문 내역" && <MyPageOrderList />}
               {currentSelectedTab === "상품 후기" && <MyReview />}
               {currentSelectedTab === "잇다톡"}
+              {currentSelectedTab === "판매자 정보" && <SellerInfoEdit />}
               {currentSelectedTab === "개인 정보 수정" &&
-                (!isLoggedIn ? (
-                  <MyInfoEditBefore />
-                ) : isSeller ? (
-                  <SellerInfoEdit />
-                ) : (
-                  <MyInfoEditAfter />
-                ))}
+                (!isLoggedIn ? <MyInfoEditBefore /> : <MyInfoEditAfter />)}
               {currentSelectedTab === "등록 상품 조회" && (
                 <>등록된 상품 목록 보여주기</>
               )}

--- a/itda-front/src/components/MyPage/MyPage.tsx
+++ b/itda-front/src/components/MyPage/MyPage.tsx
@@ -8,6 +8,7 @@ import MyInfoEditBefore from "./MyPageInfo/MyInfoEditBefore";
 import MyInfoEditAfter from "./MyPageInfo/MyInfoEditAfter";
 import { SellerInfoEdit } from "./SellerPage";
 
+// todo: 관리해야 할 상태가 너무 많아짐. recoil로 관리할 수 있게 뺄 것.
 const MyPage = () => {
   const [currentSelectedTab, setCurrentSelectedTab] = useState("주문 내역");
   console.log(currentSelectedTab);
@@ -17,6 +18,8 @@ const MyPage = () => {
   const [isSeller, setIsSeller] = useState(true);
   //하위 탭이 보여지는 상태
   const [isSubtabVisible, setIsSubtabVisible] = useState(false);
+  const [currentSelectedSubTab, setCurrentSelectedSubtab] =
+    useState("기본정보");
 
   const handleTabClick = (tabName: string) => {
     setCurrentSelectedTab(tabName);
@@ -36,6 +39,7 @@ const MyPage = () => {
               setIsSubtabVisible={setIsSubtabVisible}
               currentSelectedTab={currentSelectedTab}
               setCurrentSelectedTab={setCurrentSelectedTab}
+              setCurrentSelectedSubtab={setCurrentSelectedSubtab}
               handleTabClick={handleTabClick}
             />
           </S.MyPage.SideTabLayout>
@@ -44,9 +48,14 @@ const MyPage = () => {
               {currentSelectedTab === "주문 내역" && <MyPageOrderList />}
               {currentSelectedTab === "상품 후기" && <MyReview />}
               {currentSelectedTab === "잇다톡"}
-              {currentSelectedTab === "판매자 정보" && <SellerInfoEdit />}
               {currentSelectedTab === "개인 정보 수정" &&
-                (!isLoggedIn ? <MyInfoEditBefore /> : <MyInfoEditAfter />)}
+                (!isLoggedIn ? (
+                  <MyInfoEditBefore />
+                ) : currentSelectedSubTab === "기본정보" ? (
+                  <MyInfoEditAfter />
+                ) : (
+                  <SellerInfoEdit />
+                ))}
               {currentSelectedTab === "등록 상품 조회" && (
                 <>등록된 상품 목록 보여주기</>
               )}

--- a/itda-front/src/components/MyPage/MyPage.tsx
+++ b/itda-front/src/components/MyPage/MyPage.tsx
@@ -14,6 +14,8 @@ const MyPage = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(true);
   //임시로 만든 판매자 식별 상태 => 판매자용 화면/탭 보기: true
   const [isSeller, setIsSeller] = useState(true);
+  //하위 탭이 보여지는 상태
+  const [isSubtabVisible, setIsSubtabVisible] = useState(false);
 
   const handleTabClick = (tabName: string) => {
     setCurrentSelectedTab(tabName);
@@ -29,6 +31,8 @@ const MyPage = () => {
           <S.MyPage.SideTabLayout>
             <MyPageTabs
               isSeller={isSeller}
+              isSubtabVisible={isSubtabVisible}
+              setIsSubtabVisible={setIsSubtabVisible}
               currentSelectedTab={currentSelectedTab}
               handleTabClick={handleTabClick}
             />

--- a/itda-front/src/components/MyPage/MyPage.tsx
+++ b/itda-front/src/components/MyPage/MyPage.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import S from "./MyPageStyles";
 import Header from "components/common/Header";
-import MyPageTabs from "components/MyPage/MyPageTabs";
-import MyReview from "components/MyPage/MyReview";
-import MyPageOrderList from "./MyPageOrderList";
-import MyInfoEditBefore from "./MyInfoEditBefore";
-import MyInfoEditAfter from "./MyInfoEditAfter";
+import MyPageTabs from "components/MyPage/MyPageTab/MyPageTabs";
+import MyReview from "components/MyPage/MyPageReview/MyReview";
+import MyPageOrderList from "./MyPageOrderList/MyPageOrderList";
+import MyInfoEditBefore from "./MyPageInfo/MyInfoEditBefore";
+import MyInfoEditAfter from "./MyPageInfo/MyInfoEditAfter";
 import { SellerInfoEdit } from "./SellerPage";
 
 const MyPage = () => {

--- a/itda-front/src/components/MyPage/MyPage.tsx
+++ b/itda-front/src/components/MyPage/MyPage.tsx
@@ -12,8 +12,8 @@ const MyPage = () => {
   const [currentSelectedTab, setCurrentSelectedTab] = useState("주문 내역");
   //임시로 만든 로그인 상태: true => 기본정보수정 페이지, 판매자 페이지 보여짐
   const [isLoggedIn, setIsLoggedIn] = useState(true);
-  //임시로 만든 판매자 식별 상태 => seller화면 보기: true
-  const [isSeller, setIsSeller] = useState(false);
+  //임시로 만든 판매자 식별 상태 => 판매자용 화면/탭 보기: true
+  const [isSeller, setIsSeller] = useState(true);
 
   const handleTabClick = (tabName: string) => {
     setCurrentSelectedTab(tabName);
@@ -28,6 +28,7 @@ const MyPage = () => {
         <S.MyPage.MainLayout>
           <S.MyPage.SideTabLayout>
             <MyPageTabs
+              isSeller={isSeller}
               currentSelectedTab={currentSelectedTab}
               handleTabClick={handleTabClick}
             />
@@ -45,6 +46,9 @@ const MyPage = () => {
                 ) : (
                   <MyInfoEditAfter />
                 ))}
+              {currentSelectedTab === "등록 상품 조회" && (
+                <>등록된 상품 목록 보여주기</>
+              )}
             </S.MyPage.ContentLayer>
           </S.MyPage.ContentLayout>
         </S.MyPage.MainLayout>

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditAfter.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditAfter.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import TextInput from "components/common/Atoms/TextInput";
 import ColorButton from "components/common/Atoms/ColorButton";
 import theme from "styles/theme";
-import S from "./MyPageStyles";
+import S from "../MyPageStyles";
 
 const MyInfoEditAfter = () => {
   const [testState, setTestState] = useState("");

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditBefore.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditBefore.tsx
@@ -1,6 +1,6 @@
 import ColorButton from "components/common/Atoms/ColorButton";
 import theme from "styles/theme";
-import S from "./MyPageStyles";
+import S from "../MyPageStyles";
 import TextInput from "components/common/Atoms/TextInput";
 import { useState } from "react";
 

--- a/itda-front/src/components/MyPage/MyPageOrderList/MyPageOrderList.tsx
+++ b/itda-front/src/components/MyPage/MyPageOrderList/MyPageOrderList.tsx
@@ -1,7 +1,7 @@
 import OrderList from "components/common/Atoms/OrderList";
 import useToggle from "hooks/useToggle";
 import orders from "util/mock/orderListData";
-import ReviewWriteForm from "./ReviewWriteForm";
+import ReviewWriteForm from "../MyPageReview/ReviewWriteForm";
 
 const MyPageOrderList = () => {
   const [isReviewModalOpen, toggleReviewModal] = useToggle(false);

--- a/itda-front/src/components/MyPage/MyPageReview/MyReview.tsx
+++ b/itda-front/src/components/MyPage/MyPageReview/MyReview.tsx
@@ -1,4 +1,4 @@
-import S from "./MyPageStyles";
+import S from "../MyPageStyles";
 
 const MyReview = () => {
   return (

--- a/itda-front/src/components/MyPage/MyPageReview/ReviewWriteForm.tsx
+++ b/itda-front/src/components/MyPage/MyPageReview/ReviewWriteForm.tsx
@@ -1,7 +1,7 @@
 import ColorButton from "components/common/Atoms/ColorButton";
 import React from "react";
 import theme from "styles/theme";
-import S from "./MyPageStyles";
+import S from "../MyPageStyles";
 
 const ReviewWriteForm = ({
   handleModalOpen,

--- a/itda-front/src/components/MyPage/MyPageStyles.ts
+++ b/itda-front/src/components/MyPage/MyPageStyles.ts
@@ -56,7 +56,11 @@ const S = {
   },
 
   MyPageTab: {
-    Layout: styled.div<{
+    Layout: styled.div`
+      position: relative;
+    `,
+
+    TabLayer: styled.div<{
       category: string;
       currentSelectedTab: string;
     }>`
@@ -81,6 +85,27 @@ const S = {
         color: ${({ theme }) => theme.colors.navy.normal};
         transition: color 0.3s;
       }
+    `,
+
+    SubtabLayer: styled.div`
+      position: absolute;
+      left: 270px;
+      top: 0;
+      width: 130px;
+      cursor: pointer;
+    `,
+  },
+
+  SellerSubtabs: {
+    Layout: styled.ul`
+      border: 1px solid ${({ theme }) => theme.colors.gray.light};
+      border-radius: 15px;
+    `,
+
+    Subtab: styled.li`
+      text-align: center;
+      border: 1px solid red;
+      padding: 1rem;
     `,
   },
 

--- a/itda-front/src/components/MyPage/MyPageStyles.ts
+++ b/itda-front/src/components/MyPage/MyPageStyles.ts
@@ -1,7 +1,6 @@
 import styled, { css } from "styled-components";
 import TextField from "@material-ui/core/TextField";
 import Button from "@material-ui/core/Button";
-import theme from "styles/theme";
 
 const inputBlockStyle = css`
   display: flex;
@@ -104,8 +103,10 @@ const S = {
 
     Subtab: styled.li`
       text-align: center;
-      border: 1px solid red;
       padding: 1rem;
+      :first-child {
+        border-bottom: 1px solid ${({ theme }) => theme.colors.gray.light};
+      }
     `,
   },
 

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
@@ -26,11 +26,8 @@ const MyPageTab = ({
     }
   };
 
-  // todo: 하위탭에 마우스가 올라왔는지도 확인해야 함.
   const handleMouseLeave = () => {
-    setTimeout(() => {
-      setIsSubtabVisible(false);
-    }, 1000);
+    setIsSubtabVisible(false);
   };
 
   return (
@@ -40,14 +37,17 @@ const MyPageTab = ({
         currentSelectedTab={currentSelectedTab}
         onClick={() => handleTabClick(category)}
         onMouseEnter={() => handleMouseEnter()}
-        onMouseLeave={() => handleMouseLeave()}
+        // onMouseLeave={() => handleMouseLeave()}
       >
         {category}
       </S.MyPageTab.TabLayer>
       <S.MyPageTab.SubtabLayer>
         {category === "개인 정보 수정" &&
           (isSubtabVisible ? (
-            <SellerSubtabs setCurrentSelectedTab={setCurrentSelectedTab} />
+            <SellerSubtabs
+              setCurrentSelectedTab={setCurrentSelectedTab}
+              handleMouseLeave={handleMouseLeave}
+            />
           ) : (
             <></>
           ))}

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
@@ -2,6 +2,7 @@ import SellerSubtabs from "./SellerSubtabs";
 import S from "../MyPageStyles";
 
 interface IMyPageTabProps {
+  isSeller: boolean;
   category: string;
   isSubtabVisible: boolean;
   setIsSubtabVisible: (param: boolean) => void;
@@ -11,6 +12,7 @@ interface IMyPageTabProps {
 }
 
 const MyPageTab = ({
+  isSeller,
   category,
   isSubtabVisible,
   setIsSubtabVisible,
@@ -19,7 +21,7 @@ const MyPageTab = ({
   handleTabClick,
 }: IMyPageTabProps) => {
   const handleMouseEnter = () => {
-    if (category === "개인 정보 수정") {
+    if (isSeller && category === "개인 정보 수정") {
       setIsSubtabVisible(true);
     }
   };

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
@@ -1,4 +1,4 @@
-import S from "./MyPageStyles";
+import S from "../MyPageStyles";
 
 interface IMyPageTabProps {
   category: string;
@@ -12,6 +12,8 @@ const MyPageTab = ({
   handleTabClick,
 }: IMyPageTabProps) => {
   const handleMouseEnter = () => {
+    if (category === "개인 정보 수정") {
+    }
     // todo: 탭에 마우스가 들어왔을 때 탭 이름이 "개인정보수정"이라면, 하위 탭의 "기본정보"와 "판매자정보"를 보여주기
   };
 

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
@@ -8,6 +8,7 @@ interface IMyPageTabProps {
   setIsSubtabVisible: (param: boolean) => void;
   currentSelectedTab: string;
   setCurrentSelectedTab: (tabName: string) => void;
+  setCurrentSelectedSubtab: (tabName: string) => void;
   handleTabClick: (tabName: string) => void;
 }
 
@@ -18,6 +19,7 @@ const MyPageTab = ({
   setIsSubtabVisible,
   currentSelectedTab,
   setCurrentSelectedTab,
+  setCurrentSelectedSubtab,
   handleTabClick,
 }: IMyPageTabProps) => {
   const handleMouseEnter = () => {
@@ -37,7 +39,6 @@ const MyPageTab = ({
         currentSelectedTab={currentSelectedTab}
         onClick={() => handleTabClick(category)}
         onMouseEnter={() => handleMouseEnter()}
-        // onMouseLeave={() => handleMouseLeave()}
       >
         {category}
       </S.MyPageTab.TabLayer>
@@ -46,6 +47,7 @@ const MyPageTab = ({
           (isSubtabVisible ? (
             <SellerSubtabs
               setCurrentSelectedTab={setCurrentSelectedTab}
+              setCurrentSelectedSubtab={setCurrentSelectedSubtab}
               handleMouseLeave={handleMouseLeave}
             />
           ) : (

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
@@ -6,6 +6,7 @@ interface IMyPageTabProps {
   isSubtabVisible: boolean;
   setIsSubtabVisible: (param: boolean) => void;
   currentSelectedTab: string;
+  setCurrentSelectedTab: (tabName: string) => void;
   handleTabClick: (tabName: string) => void;
 }
 
@@ -14,6 +15,7 @@ const MyPageTab = ({
   isSubtabVisible,
   setIsSubtabVisible,
   currentSelectedTab,
+  setCurrentSelectedTab,
   handleTabClick,
 }: IMyPageTabProps) => {
   const handleMouseEnter = () => {
@@ -26,7 +28,7 @@ const MyPageTab = ({
   const handleMouseLeave = () => {
     setTimeout(() => {
       setIsSubtabVisible(false);
-    }, 500);
+    }, 1000);
   };
 
   return (
@@ -42,7 +44,11 @@ const MyPageTab = ({
       </S.MyPageTab.TabLayer>
       <S.MyPageTab.SubtabLayer>
         {category === "개인 정보 수정" &&
-          (isSubtabVisible ? <SellerSubtabs /> : <></>)}
+          (isSubtabVisible ? (
+            <SellerSubtabs setCurrentSelectedTab={setCurrentSelectedTab} />
+          ) : (
+            <></>
+          ))}
       </S.MyPageTab.SubtabLayer>
     </S.MyPageTab.Layout>
   );

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTab.tsx
@@ -1,30 +1,49 @@
+import SellerSubtabs from "./SellerSubtabs";
 import S from "../MyPageStyles";
 
 interface IMyPageTabProps {
   category: string;
+  isSubtabVisible: boolean;
+  setIsSubtabVisible: (param: boolean) => void;
   currentSelectedTab: string;
   handleTabClick: (tabName: string) => void;
 }
 
 const MyPageTab = ({
   category,
+  isSubtabVisible,
+  setIsSubtabVisible,
   currentSelectedTab,
   handleTabClick,
 }: IMyPageTabProps) => {
   const handleMouseEnter = () => {
     if (category === "개인 정보 수정") {
+      setIsSubtabVisible(true);
     }
-    // todo: 탭에 마우스가 들어왔을 때 탭 이름이 "개인정보수정"이라면, 하위 탭의 "기본정보"와 "판매자정보"를 보여주기
+  };
+
+  // todo: 하위탭에 마우스가 올라왔는지도 확인해야 함.
+  const handleMouseLeave = () => {
+    setTimeout(() => {
+      setIsSubtabVisible(false);
+    }, 500);
   };
 
   return (
-    <S.MyPageTab.Layout
-      category={category}
-      currentSelectedTab={currentSelectedTab}
-      onClick={() => handleTabClick(category)}
-      onMouseEnter={() => handleMouseEnter()}
-    >
-      {category}
+    <S.MyPageTab.Layout>
+      <S.MyPageTab.TabLayer
+        category={category}
+        currentSelectedTab={currentSelectedTab}
+        onClick={() => handleTabClick(category)}
+        onMouseEnter={() => handleMouseEnter()}
+        onMouseLeave={() => handleMouseLeave()}
+      >
+        {category}
+      </S.MyPageTab.TabLayer>
+      <S.MyPageTab.SubtabLayer>
+        {category === "개인 정보 수정" &&
+          (isSubtabVisible ? <SellerSubtabs /> : <></>)}
+      </S.MyPageTab.SubtabLayer>
     </S.MyPageTab.Layout>
   );
 };

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTabs.tsx
@@ -30,27 +30,17 @@ const MyPageTabs = ({
   return (
     <S.MyPageTabs.Layout>
       <S.MyPageTabs.Layer>
-        {isSeller
-          ? sellerTabs.map((tab) => (
-              <MyPageTab
-                category={tab}
-                isSubtabVisible={isSubtabVisible}
-                setIsSubtabVisible={setIsSubtabVisible}
-                currentSelectedTab={currentSelectedTab}
-                setCurrentSelectedTab={setCurrentSelectedTab}
-                handleTabClick={handleTabClick}
-              />
-            ))
-          : customerTabs.map((tab) => (
-              <MyPageTab
-                category={tab}
-                isSubtabVisible={isSubtabVisible}
-                setIsSubtabVisible={setIsSubtabVisible}
-                currentSelectedTab={currentSelectedTab}
-                setCurrentSelectedTab={setCurrentSelectedTab}
-                handleTabClick={handleTabClick}
-              />
-            ))}
+        {(isSeller ? sellerTabs : customerTabs).map((tab) => (
+          <MyPageTab
+            isSeller={isSeller}
+            category={tab}
+            isSubtabVisible={isSubtabVisible}
+            setIsSubtabVisible={setIsSubtabVisible}
+            currentSelectedTab={currentSelectedTab}
+            setCurrentSelectedTab={setCurrentSelectedTab}
+            handleTabClick={handleTabClick}
+          />
+        ))}
       </S.MyPageTabs.Layer>
     </S.MyPageTabs.Layout>
   );

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTabs.tsx
@@ -7,6 +7,7 @@ interface IMyPageTabsProps {
   setIsSubtabVisible: (param: boolean) => void;
   currentSelectedTab: string;
   setCurrentSelectedTab: (tabName: string) => void;
+  setCurrentSelectedSubtab: (tabName: string) => void;
   handleTabClick: (tabName: string) => void;
 }
 
@@ -16,6 +17,7 @@ const MyPageTabs = ({
   setIsSubtabVisible,
   currentSelectedTab,
   setCurrentSelectedTab,
+  setCurrentSelectedSubtab,
   handleTabClick,
 }: IMyPageTabsProps) => {
   const customerTabs = ["주문 내역", "상품 후기", "잇다톡", "개인 정보 수정"];
@@ -38,6 +40,7 @@ const MyPageTabs = ({
             setIsSubtabVisible={setIsSubtabVisible}
             currentSelectedTab={currentSelectedTab}
             setCurrentSelectedTab={setCurrentSelectedTab}
+            setCurrentSelectedSubtab={setCurrentSelectedSubtab}
             handleTabClick={handleTabClick}
           />
         ))}

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTabs.tsx
@@ -6,6 +6,7 @@ interface IMyPageTabsProps {
   isSubtabVisible: boolean;
   setIsSubtabVisible: (param: boolean) => void;
   currentSelectedTab: string;
+  setCurrentSelectedTab: (tabName: string) => void;
   handleTabClick: (tabName: string) => void;
 }
 
@@ -14,6 +15,7 @@ const MyPageTabs = ({
   isSubtabVisible,
   setIsSubtabVisible,
   currentSelectedTab,
+  setCurrentSelectedTab,
   handleTabClick,
 }: IMyPageTabsProps) => {
   const customerTabs = ["주문 내역", "상품 후기", "잇다톡", "개인 정보 수정"];
@@ -35,6 +37,7 @@ const MyPageTabs = ({
                 isSubtabVisible={isSubtabVisible}
                 setIsSubtabVisible={setIsSubtabVisible}
                 currentSelectedTab={currentSelectedTab}
+                setCurrentSelectedTab={setCurrentSelectedTab}
                 handleTabClick={handleTabClick}
               />
             ))
@@ -44,6 +47,7 @@ const MyPageTabs = ({
                 isSubtabVisible={isSubtabVisible}
                 setIsSubtabVisible={setIsSubtabVisible}
                 currentSelectedTab={currentSelectedTab}
+                setCurrentSelectedTab={setCurrentSelectedTab}
                 handleTabClick={handleTabClick}
               />
             ))}

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTabs.tsx
@@ -1,5 +1,6 @@
-import S from "./MyPageStyles";
-import MyPageTab from "components/MyPage/MyPageTab";
+import { useState } from "react";
+import MyPageTab from "components/MyPage/MyPageTab/MyPageTab";
+import S from "../MyPageStyles";
 
 interface IMyPageTabsProps {
   isSeller: boolean;
@@ -20,6 +21,8 @@ const MyPageTabs = ({
     "개인 정보 수정",
     "등록 상품 조회",
   ];
+  const [isSubtabActive, setIsSubtabActive] = useState(false);
+
   return (
     <S.MyPageTabs.Layout>
       <S.MyPageTabs.Layer>

--- a/itda-front/src/components/MyPage/MyPageTab/MyPageTabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/MyPageTabs.tsx
@@ -1,15 +1,18 @@
-import { useState } from "react";
 import MyPageTab from "components/MyPage/MyPageTab/MyPageTab";
 import S from "../MyPageStyles";
 
 interface IMyPageTabsProps {
   isSeller: boolean;
+  isSubtabVisible: boolean;
+  setIsSubtabVisible: (param: boolean) => void;
   currentSelectedTab: string;
   handleTabClick: (tabName: string) => void;
 }
 
 const MyPageTabs = ({
   isSeller,
+  isSubtabVisible,
+  setIsSubtabVisible,
   currentSelectedTab,
   handleTabClick,
 }: IMyPageTabsProps) => {
@@ -21,7 +24,6 @@ const MyPageTabs = ({
     "개인 정보 수정",
     "등록 상품 조회",
   ];
-  const [isSubtabActive, setIsSubtabActive] = useState(false);
 
   return (
     <S.MyPageTabs.Layout>
@@ -30,6 +32,8 @@ const MyPageTabs = ({
           ? sellerTabs.map((tab) => (
               <MyPageTab
                 category={tab}
+                isSubtabVisible={isSubtabVisible}
+                setIsSubtabVisible={setIsSubtabVisible}
                 currentSelectedTab={currentSelectedTab}
                 handleTabClick={handleTabClick}
               />
@@ -37,6 +41,8 @@ const MyPageTabs = ({
           : customerTabs.map((tab) => (
               <MyPageTab
                 category={tab}
+                isSubtabVisible={isSubtabVisible}
+                setIsSubtabVisible={setIsSubtabVisible}
                 currentSelectedTab={currentSelectedTab}
                 handleTabClick={handleTabClick}
               />

--- a/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
@@ -1,11 +1,27 @@
 import S from "../MyPageStyles";
 
-const SellerSubtabs = () => {
+interface ISellerSubtabsProps {
+  setCurrentSelectedTab: (tabName: string) => void;
+}
+
+const SellerSubtabs = ({ setCurrentSelectedTab }: ISellerSubtabsProps) => {
   const subtabTitles = ["기본정보", "판매자 정보"];
+
+  const handleSubtabClick = (tabName: string) => {
+    if (tabName === "기본정보") {
+      setCurrentSelectedTab("개인 정보 수정");
+    }
+    if (tabName === "판매자 정보") {
+      setCurrentSelectedTab("퍈매자 정보");
+    }
+  };
+
   return (
     <S.SellerSubtabs.Layout>
       {subtabTitles.map((subtab) => (
-        <S.SellerSubtabs.Subtab>{subtab}</S.SellerSubtabs.Subtab>
+        <S.SellerSubtabs.Subtab onClick={() => handleSubtabClick(subtab)}>
+          {subtab}
+        </S.SellerSubtabs.Subtab>
       ))}
     </S.SellerSubtabs.Layout>
   );

--- a/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
@@ -1,0 +1,5 @@
+const SellerSubtabs = () => {
+  return <div></div>;
+};
+
+export default SellerSubtabs;

--- a/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
@@ -1,5 +1,14 @@
+import S from "../MyPageStyles";
+
 const SellerSubtabs = () => {
-  return <div></div>;
+  const subtabTitles = ["기본정보", "판매자 정보"];
+  return (
+    <S.SellerSubtabs.Layout>
+      {subtabTitles.map((subtab) => (
+        <S.SellerSubtabs.Subtab>{subtab}</S.SellerSubtabs.Subtab>
+      ))}
+    </S.SellerSubtabs.Layout>
+  );
 };
 
 export default SellerSubtabs;

--- a/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
@@ -2,9 +2,13 @@ import S from "../MyPageStyles";
 
 interface ISellerSubtabsProps {
   setCurrentSelectedTab: (tabName: string) => void;
+  handleMouseLeave: () => void;
 }
 
-const SellerSubtabs = ({ setCurrentSelectedTab }: ISellerSubtabsProps) => {
+const SellerSubtabs = ({
+  setCurrentSelectedTab,
+  handleMouseLeave,
+}: ISellerSubtabsProps) => {
   const subtabTitles = ["기본정보", "판매자 정보"];
 
   const handleSubtabClick = (tabName: string) => {
@@ -17,7 +21,7 @@ const SellerSubtabs = ({ setCurrentSelectedTab }: ISellerSubtabsProps) => {
   };
 
   return (
-    <S.SellerSubtabs.Layout>
+    <S.SellerSubtabs.Layout onMouseLeave={handleMouseLeave}>
       {subtabTitles.map((subtab) => (
         <S.SellerSubtabs.Subtab onClick={() => handleSubtabClick(subtab)}>
           {subtab}

--- a/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
@@ -2,21 +2,25 @@ import S from "../MyPageStyles";
 
 interface ISellerSubtabsProps {
   setCurrentSelectedTab: (tabName: string) => void;
+  setCurrentSelectedSubtab: (tabName: string) => void;
   handleMouseLeave: () => void;
 }
 
 const SellerSubtabs = ({
   setCurrentSelectedTab,
   handleMouseLeave,
+  setCurrentSelectedSubtab,
 }: ISellerSubtabsProps) => {
   const subtabTitles = ["기본정보", "판매자 정보"];
 
   const handleSubtabClick = (tabName: string) => {
     if (tabName === "기본정보") {
       setCurrentSelectedTab("개인 정보 수정");
+      setCurrentSelectedSubtab("기본정보");
     }
     if (tabName === "판매자 정보") {
-      setCurrentSelectedTab("퍈매자 정보");
+      setCurrentSelectedTab("개인 정보 수정");
+      setCurrentSelectedSubtab("판매자 정보");
     }
   };
 

--- a/itda-front/src/components/MyPage/MyPageTabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTabs.tsx
@@ -2,26 +2,42 @@ import S from "./MyPageStyles";
 import MyPageTab from "components/MyPage/MyPageTab";
 
 interface IMyPageTabsProps {
+  isSeller: boolean;
   currentSelectedTab: string;
   handleTabClick: (tabName: string) => void;
 }
 
 const MyPageTabs = ({
+  isSeller,
   currentSelectedTab,
   handleTabClick,
 }: IMyPageTabsProps) => {
-  const tabs = ["주문 내역", "상품 후기", "잇다톡", "개인 정보 수정"];
-  // todo: 판매자의 경우, '등록상품조회'라는 탭이 추가로 보여져야함.
+  const customerTabs = ["주문 내역", "상품 후기", "잇다톡", "개인 정보 수정"];
+  const sellerTabs = [
+    "주문 내역",
+    "상품 후기",
+    "잇다톡",
+    "개인 정보 수정",
+    "등록 상품 조회",
+  ];
   return (
     <S.MyPageTabs.Layout>
       <S.MyPageTabs.Layer>
-        {tabs.map((tab, index) => (
-          <MyPageTab
-            category={tab}
-            currentSelectedTab={currentSelectedTab}
-            handleTabClick={handleTabClick}
-          />
-        ))}
+        {isSeller
+          ? sellerTabs.map((tab) => (
+              <MyPageTab
+                category={tab}
+                currentSelectedTab={currentSelectedTab}
+                handleTabClick={handleTabClick}
+              />
+            ))
+          : customerTabs.map((tab) => (
+              <MyPageTab
+                category={tab}
+                currentSelectedTab={currentSelectedTab}
+                handleTabClick={handleTabClick}
+              />
+            ))}
       </S.MyPageTabs.Layer>
     </S.MyPageTabs.Layout>
   );

--- a/itda-front/src/router/Router.tsx
+++ b/itda-front/src/router/Router.tsx
@@ -10,7 +10,7 @@ import Cart from "components/Cart";
 import ThankYou from "components/ThankYou";
 import { Route, Switch, BrowserRouter } from "react-router-dom";
 import SignUpCompletePage from "components/SignUp/SignUpCompletePage";
-import MyReview from "components/MyPage/MyReview";
+import MyReview from "components/MyPage/MyPageReview/MyReview";
 
 const Router = () => {
   return (


### PR DESCRIPTION
## 📌 개요

- Close #151 
- Close #154
- MyPage에 판매자용 등록상품조회 tab 추가하기

## 👩‍💻 작업 사항

- [x] 판매자일 때만 보여지도록 조건 설정
- [x] 등록상품조회 tab 추가하기
- [x] 판매자용 subTab(기본정보, 판매자정보) 추가 => subTab onMouseLeave 이벤트로 닫히는 문제 해결

## ✅ 참고 사항
![image](https://user-images.githubusercontent.com/65105537/133383727-d05072a6-62e1-48c2-9449-920fbda7a041.png)
![image](https://user-images.githubusercontent.com/65105537/134137301-aeba94cf-6160-4b54-9b63-8be79a4d00d1.png)
