### PR TITLE
[FEAT/FIX] 개인정보수정 페이지 PrivateRoute 적용 + subTab 클릭 시 페이지 전환 로직 적용

### DIFF
--- a/itda-front/src/components/MyPage/MyPage.tsx
+++ b/itda-front/src/components/MyPage/MyPage.tsx
@@ -3,6 +3,9 @@ import S from "./MyPageStyles";
 import MyReview from "components/MyPage/MyPageReview/MyReview";
 import MyPageOrderList from "./MyPageOrderList/MyPageOrderList";
 import MyInfoEditBefore from "./MyPageInfo/MyInfoEditBefore";
+import MyInfoEditAfter from "./MyPageInfo/MyInfoEditAfter";
+import PrivateRouter from "router/PrivateRouter";
+import isPasswordCorrect from "util/isPasswordCorrect";
 
 const MyPage = () => {
   return (
@@ -13,7 +16,13 @@ const MyPage = () => {
           <Route path="/myPage/orderList" component={MyPageOrderList} />
           <Route path="/myPage/reviews" component={MyReview} />
           <Route path="/myPage/itdaTalk" />
-          <Route path="/myPage/myInfoEdit" component={MyInfoEditBefore} />
+          <Route path="/myPage/myInfoEditBefore" component={MyInfoEditBefore} />
+          <PrivateRouter
+            path="/myPage/myInfoEdit"
+            redirectPath="/myPage/myInfoEditBefore"
+            validationFunc={isPasswordCorrect}
+            component={MyInfoEditAfter}
+          />
         </Switch>
       </S.MyPage.Layout>
     </>

--- a/itda-front/src/components/MyPage/MyPage.tsx
+++ b/itda-front/src/components/MyPage/MyPage.tsx
@@ -4,6 +4,7 @@ import MyReview from "components/MyPage/MyPageReview/MyReview";
 import MyPageOrderList from "./MyPageOrderList/MyPageOrderList";
 import MyInfoEditBefore from "./MyPageInfo/MyInfoEditBefore";
 import MyInfoEditAfter from "./MyPageInfo/MyInfoEditAfter";
+import { SellerInfoEdit } from "./SellerPage";
 import PrivateRouter from "router/PrivateRouter";
 import isPasswordCorrect from "util/isPasswordCorrect";
 
@@ -17,6 +18,7 @@ const MyPage = () => {
           <Route path="/myPage/reviews" component={MyReview} />
           <Route path="/myPage/itdaTalk" />
           <Route path="/myPage/myInfoEditBefore" component={MyInfoEditBefore} />
+          <Route path="/myPage/myInfoEdit/seller" component={SellerInfoEdit} />
           <PrivateRouter
             path="/myPage/myInfoEdit"
             redirectPath="/myPage/myInfoEditBefore"

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditAfter.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditAfter.tsx
@@ -8,7 +8,7 @@ import MyPageTabs from "../MyPageTab/MyPageTabs";
 
 const MyInfoEditAfter = () => {
   const [testState, setTestState] = useState("");
-  const [isSeller, setIsSeller] = useState(true);
+  const [isSeller, setIsSeller] = useState(true); //임시
 
   return (
     <>

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditBefore.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditBefore.tsx
@@ -1,5 +1,3 @@
-import { useRecoilValue } from "recoil";
-import { Route, Switch } from "react-router-dom";
 import ColorButton from "components/common/Atoms/ColorButton";
 import theme from "styles/theme";
 import S from "../MyPageStyles";
@@ -7,12 +5,8 @@ import TextInput from "components/common/Atoms/TextInput";
 import { useState } from "react";
 import Header from "components/common/Header";
 import MyPageTabs from "../MyPageTab/MyPageTabs";
-import MyInfoEditAfter from "./MyInfoEditAfter";
-import { SellerInfoEdit } from "../SellerPage";
-import { currentSelectedSubtab } from "stores/MyPageAtoms";
 
 const MyInfoEditBefore = () => {
-  const currentSelectedSubtabState = useRecoilValue(currentSelectedSubtab);
   const [testState, setTestState] = useState("");
   const [isSeller, setIsSeller] = useState(true);
   return (

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditBefore.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditBefore.tsx
@@ -10,11 +10,9 @@ import MyPageTabs from "../MyPageTab/MyPageTabs";
 import MyInfoEditAfter from "./MyInfoEditAfter";
 import { SellerInfoEdit } from "../SellerPage";
 import { currentSelectedSubtab } from "stores/MyPageAtoms";
-import { isLoggedIn } from "stores/LoginAtoms";
 
 const MyInfoEditBefore = () => {
   const currentSelectedSubtabState = useRecoilValue(currentSelectedSubtab);
-  const isLoggedInState = useRecoilValue(isLoggedIn);
   const [testState, setTestState] = useState("");
   const [isSeller, setIsSeller] = useState(true);
   return (
@@ -29,71 +27,49 @@ const MyInfoEditBefore = () => {
         <S.MyPage.ContentLayout>
           <S.MyPage.ContentLayer>
             <S.MyInfoBefore.Layout>
-              {isLoggedInState ? (
-                <>
-                  <S.MyInfoBefore.HeaderLayer>
-                    개인정보 수정
-                  </S.MyInfoBefore.HeaderLayer>
-                  <S.MyInfoBefore.TitleLayer>
-                    <div>비밀번호 재확인</div>
-                    <div>
-                      회원님의 정보를 안전하게 보호하기 위해 비밀번호를 다시
-                      한번 확인해주세요.
-                    </div>
-                  </S.MyInfoBefore.TitleLayer>
-                  <S.MyInfoBefore.Divider3px />
-                  <S.MyInfoBefore.FormLayer>
-                    <S.MyInfoBefore.FormBlock>
-                      <S.MyInfoBefore.FormTitle>
-                        아이디
-                      </S.MyInfoBefore.FormTitle>
-                      <TextInput
-                        width={"100%"}
-                        size="medium"
-                        state={testState}
-                        setState={setTestState}
-                      />
-                    </S.MyInfoBefore.FormBlock>
-                    <S.MyInfoBefore.FormBlock>
-                      <S.MyInfoBefore.FormTitle>
-                        비밀번호
-                      </S.MyInfoBefore.FormTitle>
-                      <TextInput
-                        width={"100%"}
-                        size="medium"
-                        state={testState}
-                        setState={setTestState}
-                      />
-                    </S.MyInfoBefore.FormBlock>
-                  </S.MyInfoBefore.FormLayer>
-                  <S.MyInfoBefore.Divider1px />
-                  <S.MyInfoBefore.ButtonLayer>
-                    <ColorButton
-                      isWhiteButton={false}
-                      baseColor={theme.colors.navy.normal}
-                      width="30%"
-                      height="3.5rem"
-                      fontSize="18px"
-                    >
-                      확인
-                    </ColorButton>
-                  </S.MyInfoBefore.ButtonLayer>
-                </>
-              ) : currentSelectedSubtabState === "기본정보" ? (
-                <Switch>
-                  <Route
-                    path="/myPage/myInfoEdit/ok"
-                    component={MyInfoEditAfter}
+              <S.MyInfoBefore.HeaderLayer>
+                개인정보 수정
+              </S.MyInfoBefore.HeaderLayer>
+              <S.MyInfoBefore.TitleLayer>
+                <div>비밀번호 재확인</div>
+                <div>
+                  회원님의 정보를 안전하게 보호하기 위해 비밀번호를 다시 한번
+                  확인해주세요.
+                </div>
+              </S.MyInfoBefore.TitleLayer>
+              <S.MyInfoBefore.Divider3px />
+              <S.MyInfoBefore.FormLayer>
+                <S.MyInfoBefore.FormBlock>
+                  <S.MyInfoBefore.FormTitle>아이디</S.MyInfoBefore.FormTitle>
+                  <TextInput
+                    width={"100%"}
+                    size="medium"
+                    state={testState}
+                    setState={setTestState}
                   />
-                </Switch>
-              ) : (
-                <Switch>
-                  <Route
-                    path="/myPage/myInfoEdit/seller"
-                    component={SellerInfoEdit}
+                </S.MyInfoBefore.FormBlock>
+                <S.MyInfoBefore.FormBlock>
+                  <S.MyInfoBefore.FormTitle>비밀번호</S.MyInfoBefore.FormTitle>
+                  <TextInput
+                    width={"100%"}
+                    size="medium"
+                    state={testState}
+                    setState={setTestState}
                   />
-                </Switch>
-              )}
+                </S.MyInfoBefore.FormBlock>
+              </S.MyInfoBefore.FormLayer>
+              <S.MyInfoBefore.Divider1px />
+              <S.MyInfoBefore.ButtonLayer>
+                <ColorButton
+                  isWhiteButton={false}
+                  baseColor={theme.colors.navy.normal}
+                  width="30%"
+                  height="3.5rem"
+                  fontSize="18px"
+                >
+                  확인
+                </ColorButton>
+              </S.MyInfoBefore.ButtonLayer>
             </S.MyInfoBefore.Layout>
           </S.MyPage.ContentLayer>
         </S.MyPage.ContentLayout>

--- a/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
@@ -49,14 +49,12 @@ const SellerSubtabs = ({
       onMouseEnter={handleMouseEnterSubtab}
     >
       {subtabTitles.map((subtab, index) => (
-        <Link to={getPath(subtab)}>
-          <S.SellerSubtabs.Subtab
-            key={`subtab-${index}`}
-            onClick={() => handleSubtabClick(subtab)}
-          >
-            {subtab}
-          </S.SellerSubtabs.Subtab>
-        </Link>
+        <S.SellerSubtabs.Subtab
+          key={`subtab-${index}`}
+          onClick={() => handleSubtabClick(subtab)}
+        >
+          <Link to={getPath(subtab)}>{subtab} </Link>
+        </S.SellerSubtabs.Subtab>
       ))}
     </S.SellerSubtabs.Layout>
   );

--- a/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { useSetRecoilState } from "recoil";
 import S from "../MyPageStyles";
 import { currentSelectedTab, currentSelectedSubtab } from "stores/MyPageAtoms";
@@ -6,6 +7,10 @@ interface ISellerSubtabsProps {
   handleMouseLeaveSubTab: () => void;
   handleMouseEnterSubtab: () => void;
 }
+
+type TPath = {
+  [index: string]: string;
+};
 
 const SellerSubtabs = ({
   handleMouseLeaveSubTab,
@@ -16,6 +21,16 @@ const SellerSubtabs = ({
     currentSelectedSubtab
   );
   const subtabTitles = ["기본정보", "판매자 정보"];
+
+  const path: TPath = {
+    기본정보: "",
+    "판매자 정보": "seller",
+  };
+
+  const getPath = (tab: string) => {
+    let base = "/myPage/myInfoEdit/";
+    return (base += path[tab]);
+  };
 
   const handleSubtabClick = (tabName: string) => {
     if (tabName === "기본정보") {
@@ -34,12 +49,14 @@ const SellerSubtabs = ({
       onMouseEnter={handleMouseEnterSubtab}
     >
       {subtabTitles.map((subtab, index) => (
-        <S.SellerSubtabs.Subtab
-          key={`subtab-${index}`}
-          onClick={() => handleSubtabClick(subtab)}
-        >
-          {subtab}
-        </S.SellerSubtabs.Subtab>
+        <Link to={getPath(subtab)}>
+          <S.SellerSubtabs.Subtab
+            key={`subtab-${index}`}
+            onClick={() => handleSubtabClick(subtab)}
+          >
+            {subtab}
+          </S.SellerSubtabs.Subtab>
+        </Link>
       ))}
     </S.SellerSubtabs.Layout>
   );

--- a/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
+++ b/itda-front/src/components/MyPage/MyPageTab/SellerSubtabs.tsx
@@ -24,11 +24,11 @@ const SellerSubtabs = ({
 
   const path: TPath = {
     기본정보: "",
-    "판매자 정보": "seller",
+    "판매자 정보": "/seller",
   };
 
   const getPath = (tab: string) => {
-    let base = "/myPage/myInfoEdit/";
+    let base = "/myPage/myInfoEdit";
     return (base += path[tab]);
   };
 

--- a/itda-front/src/router/PrivateRouter.tsx
+++ b/itda-front/src/router/PrivateRouter.tsx
@@ -1,20 +1,25 @@
 import { Redirect, Route, RouteProps } from "react-router-dom";
-import isLogin from "util/isLogin";
 
 const PrivateRoute = ({
   component: Component,
   redirectPath,
+  validationFunc,
   ...parentProps
 }: {
   component: React.ComponentType<RouteProps>;
   path: string;
   redirectPath: string;
+  validationFunc: () => boolean;
 }) => {
   return (
     <Route
       {...parentProps}
       render={(props) =>
-        isLogin() ? <Component {...props} /> : <Redirect to={redirectPath} />
+        validationFunc() ? (
+          <Component {...props} />
+        ) : (
+          <Redirect to={redirectPath} />
+        )
       }
     />
   );

--- a/itda-front/src/router/PrivateRouter.tsx
+++ b/itda-front/src/router/PrivateRouter.tsx
@@ -3,16 +3,18 @@ import isLogin from "util/isLogin";
 
 const PrivateRoute = ({
   component: Component,
+  redirectPath,
   ...parentProps
 }: {
   component: React.ComponentType<RouteProps>;
   path: string;
+  redirectPath: string;
 }) => {
   return (
     <Route
       {...parentProps}
-      render={props =>
-        isLogin() ? <Component {...props} /> : <Redirect to={"/login"} />
+      render={(props) =>
+        isLogin() ? <Component {...props} /> : <Redirect to={redirectPath} />
       }
     />
   );

--- a/itda-front/src/router/Router.tsx
+++ b/itda-front/src/router/Router.tsx
@@ -31,9 +31,21 @@ const Router = () => {
         <Route path="/JennyTest" component={MyReview} />
         <Route exact path="/naver/callback" component={NaverCallback} />
         <Route exact path="/kakao/callback" component={KakaoCallback} />
-        <PrivateRouter path="/myPage" component={MyPage} />
-        <PrivateRouter path="/addProduct" component={AddProduct} />
-        <PrivateRouter path="/thankYou" component={ThankYou} />
+        <PrivateRouter
+          path="/myPage"
+          redirectPath="/login"
+          component={MyPage}
+        />
+        <PrivateRouter
+          path="/addProduct"
+          redirectPath="/login"
+          component={AddProduct}
+        />
+        <PrivateRouter
+          path="/thankYou"
+          redirectPath="/login"
+          component={ThankYou}
+        />
         <Route component={NotFound} />
       </Switch>
     </BrowserRouter>

--- a/itda-front/src/router/Router.tsx
+++ b/itda-front/src/router/Router.tsx
@@ -15,6 +15,7 @@ import NaverCallback from "components/Login/NaverCallback";
 import KakaoCallback from "components/Login/KakaoCallback";
 import PrivateRouter from "./PrivateRouter";
 import NotFound from "./NotFound";
+import isLogin from "util/isLogin";
 
 const Router = () => {
   return (
@@ -34,16 +35,19 @@ const Router = () => {
         <PrivateRouter
           path="/myPage"
           redirectPath="/login"
+          validationFunc={isLogin}
           component={MyPage}
         />
         <PrivateRouter
           path="/addProduct"
           redirectPath="/login"
+          validationFunc={isLogin}
           component={AddProduct}
         />
         <PrivateRouter
           path="/thankYou"
           redirectPath="/login"
+          validationFunc={isLogin}
           component={ThankYou}
         />
         <Route component={NotFound} />

--- a/itda-front/src/util/isPasswordCorrect.ts
+++ b/itda-front/src/util/isPasswordCorrect.ts
@@ -1,0 +1,6 @@
+const isPasswordCorrect = () => {
+  // todo: 백엔드로 패스워드가 일치하는지 API 요청하는 로직 필요. 비밀번호 검사. 현재는 임시.
+  return true;
+};
+
+export default isPasswordCorrect;


### PR DESCRIPTION
## 📌 개요

- Close #175 
- MyPage > 개인정보수정 에서 로그인 여부에 따라 PrivateRoute 적용하기
- Subtab 클릭 시 관련 페이지로 라우팅하는 로직 적용

## 👩‍💻 작업 사항

- [x] redirect path를 props로 받는 방법으로 정정 (재사용 목적) 
- [x] 개인정보수정 페이지 PrivateRoute 적용
- [x] subtab 클릭시 관련 컴포넌트로 이동 

## ✅ 참고 사항
데이지가 만들어주신 `PrivateRouter`를 재사용하려고 props 부분을 조금 바꾸게 되었어요..! 덕분에 편하게 적용했습미당👍
< 전 > 
![image](https://user-images.githubusercontent.com/65105537/135994671-e63531ab-7cdd-4237-b199-b8acbe59c31d.png)
< 후 >
![image](https://user-images.githubusercontent.com/65105537/136004147-4c43bb08-559f-48e1-a0c0-35a1f0f8e26b.png)
