### PR TITLE
[FEAT/FIX] SideDrawer(cart) 수량변경 버튼 추가 및 API 부분적용 

### DIFF
--- a/itda-front/src/components/Cart/CartProduct/CartProductsService.ts
+++ b/itda-front/src/components/Cart/CartProduct/CartProductsService.ts
@@ -15,4 +15,10 @@ const UpdateCartService = (cartList: any) => {
   );
 };
 
-export { CartService, UpdateCartService };
+const DeleteCartService = (productId: number) => {
+  const { data } = useQuery("deleteCartList", () =>
+    cartAPI.delete.deleteCartProduct(`/cart?productId=${productId}`)
+  );
+};
+
+export { CartService, UpdateCartService, DeleteCartService };

--- a/itda-front/src/components/Cart/CartProduct/CartProductsService.ts
+++ b/itda-front/src/components/Cart/CartProduct/CartProductsService.ts
@@ -1,0 +1,9 @@
+import { cartAPI } from "util/API/cartAPI";
+import { useQuery } from "react-query";
+
+const CartService = () => {
+  const { data, isLoading } = useQuery("cart", cartAPI.get.getCartProductList);
+  return { cartListData: data?.data, isLoading };
+};
+
+export default CartService;

--- a/itda-front/src/components/Cart/CartProduct/CartProductsService.ts
+++ b/itda-front/src/components/Cart/CartProduct/CartProductsService.ts
@@ -2,8 +2,17 @@ import { cartAPI } from "util/API/cartAPI";
 import { useQuery } from "react-query";
 
 const CartService = () => {
-  const { data, isLoading } = useQuery("cart", cartAPI.get.getCartProductList);
+  const { data, isLoading } = useQuery(
+    "cartlist",
+    cartAPI.get.getCartProductList
+  );
   return { cartListData: data?.data, isLoading };
 };
 
-export default CartService;
+const UpdateCartService = (cartList: any) => {
+  const { isError } = useQuery("updateCartList", () =>
+    cartAPI.post.updateCartProductList(cartList)
+  );
+};
+
+export { CartService, UpdateCartService };

--- a/itda-front/src/components/ProductDetail/ProductDetailButtonBlock.tsx
+++ b/itda-front/src/components/ProductDetail/ProductDetailButtonBlock.tsx
@@ -1,9 +1,16 @@
 import S from "./ProductDetailStyles";
+import { useRecoilValue } from "recoil";
 
-const ProductDetailButtonBlock = () => {
+type TProductDetailButtonBlock = {
+  handleClickAddToCartButton: () => void;
+};
+
+const ProductDetailButtonBlock = ({
+  handleClickAddToCartButton,
+}: TProductDetailButtonBlock) => {
   return (
     <S.ProductInfo.PaymentBlock>
-      <S.ProductInfo.AddToCartButton>
+      <S.ProductInfo.AddToCartButton onClick={handleClickAddToCartButton}>
         장바구니 담기
       </S.ProductInfo.AddToCartButton>
       <S.ProductInfo.BuyButton>구매하기</S.ProductInfo.BuyButton>

--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -5,6 +5,8 @@ import {
   detailProductPrice,
   detailDescription,
 } from "stores/ProductDetailAtoms";
+import { cartProductData } from "stores/CartAtoms";
+import { ICartProduct } from "types/CartTypes";
 import S from "./ProductDetailStyles";
 import { withRouter, RouteComponentProps } from "react-router";
 import ProductDetailButtonBlock from "./ProductDetailButtonBlock";
@@ -19,8 +21,10 @@ interface MatchParams {
 }
 
 const ProductInfo = ({ match }: RouteComponentProps<MatchParams>) => {
-  const setProductPrice = useSetRecoilState(detailProductPrice);
+  const [productPrice, setProductPrice] = useRecoilState(detailProductPrice);
   const setDetailDescription = useSetRecoilState(detailDescription);
+  const setCartProductData = useSetRecoilState(cartProductData);
+  const productCount = useRecoilValue(detailProductCount);
 
   const { data, isLoading } = useQuery(
     "productDetail",
@@ -33,6 +37,18 @@ const ProductInfo = ({ match }: RouteComponentProps<MatchParams>) => {
       },
     }
   );
+
+  const handleClickAddToCartButton = () => {
+    const productId = match.params.productId;
+    const targetProductData: ICartProduct = {
+      id: Number(productId),
+      count: productCount,
+      price: productPrice,
+      productName: data?.data.product.name,
+      imageUrl: data?.data.product.imgUrl,
+    };
+    setCartProductData((cartProducts) => [...cartProducts, targetProductData]);
+  };
 
   return (
     <S.ProductInfo.InfoLayout>
@@ -53,7 +69,9 @@ const ProductInfo = ({ match }: RouteComponentProps<MatchParams>) => {
           </S.ProductInfo.ProductDetailLayer>
           <S.ProductInfo.ProductPaymentLayer>
             <ProductDetailSellerBlock {...data?.data.product} />
-            <ProductDetailButtonBlock />
+            <ProductDetailButtonBlock
+              handleClickAddToCartButton={handleClickAddToCartButton}
+            />
           </S.ProductInfo.ProductPaymentLayer>
         </>
       )}

--- a/itda-front/src/components/ProductDetail/ProductInfo.tsx
+++ b/itda-front/src/components/ProductDetail/ProductInfo.tsx
@@ -22,8 +22,9 @@ interface MatchParams {
 
 const ProductInfo = ({ match }: RouteComponentProps<MatchParams>) => {
   const [productPrice, setProductPrice] = useRecoilState(detailProductPrice);
+  const [cartProductsData, setCartProductData] =
+    useRecoilState(cartProductData);
   const setDetailDescription = useSetRecoilState(detailDescription);
-  const setCartProductData = useSetRecoilState(cartProductData);
   const productCount = useRecoilValue(detailProductCount);
 
   const { data, isLoading } = useQuery(
@@ -38,16 +39,25 @@ const ProductInfo = ({ match }: RouteComponentProps<MatchParams>) => {
     }
   );
 
+  const hasSameProductInCart = (id: number) => {
+    return cartProductsData.some((product) => product.id === id);
+  };
+
   const handleClickAddToCartButton = () => {
-    const productId = match.params.productId;
+    const productId = Number(match.params.productId);
     const targetProductData: ICartProduct = {
-      id: Number(productId),
+      id: productId,
       count: productCount,
       price: productPrice,
       productName: data?.data.product.name,
       imageUrl: data?.data.product.imgUrl,
     };
-    setCartProductData((cartProducts) => [...cartProducts, targetProductData]);
+    if (!hasSameProductInCart(productId)) {
+      setCartProductData((cartProducts) => [
+        ...cartProducts,
+        targetProductData,
+      ]);
+    }
   };
 
   return (

--- a/itda-front/src/components/Products/ProductList.tsx
+++ b/itda-front/src/components/Products/ProductList.tsx
@@ -16,7 +16,6 @@ const ProductList = () => {
           productImg={imageUrl}
           productName={productName}
           productPrice={price}
-          seller={sellerName}
           description={"description이 API 응답에 없다!!이건 직접 적음"}
           id={id}
         />

--- a/itda-front/src/components/common/CommonStyles.tsx
+++ b/itda-front/src/components/common/CommonStyles.tsx
@@ -360,9 +360,11 @@ const S = {
       color: #c2c2c2;
     `,
 
-    DrawerMoveToCartButton: styled(Button)`
-      width: 100%;
+    ApplyNumbersButton: styled(Button)`
+      width: 50%;
       padding: 15px 0;
+      margin: 5px;
+      color: #ffffff;
       background: ${({ theme }) => theme.colors.navy.light};
       border: none;
       border-radius: 5px;
@@ -372,6 +374,27 @@ const S = {
         color: ${({ theme }) => theme.colors.white};
         background: ${({ theme }) => theme.colors.navy.normal};
       }
+    `,
+
+    DrawerMoveToCartButton: styled(Button)`
+      width: 50%;
+      padding: 15px 0;
+      margin: 5px;
+      color: ${({ theme }) => theme.colors.navy.light};
+      border: 2px solid ${({ theme }) => theme.colors.navy.light};
+      background-color: none;
+      border-radius: 5px;
+      margin-top: 2%;
+      &:hover {
+        cursor: pointer;
+        color: ${({ theme }) => theme.colors.white};
+        background: ${({ theme }) => theme.colors.navy.normal};
+      }
+    `,
+
+    ButtonLayer: styled.div`
+      display: flex;
+      width: 100%;
     `,
   },
   TopButton: {

--- a/itda-front/src/components/common/CommonStyles.tsx
+++ b/itda-front/src/components/common/CommonStyles.tsx
@@ -290,6 +290,11 @@ const S = {
       overflow-y: scroll;
     `,
 
+    EmptyDrawerMessage: styled.div`
+      align-self: center;
+      color: ${({ theme }) => theme.colors.mint.normal};
+    `,
+
     DrawerCardLayout: styled.div`
       display: flex;
       flex-direction: column;

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -18,10 +18,6 @@ const SideDrawer = ({
   >([]);
   const [cartTotalPrice, setCartTotalPrice] = useState(0);
 
-  const handleCloseButtonClick = () => {
-    setIsSideDrawerClicked(false);
-  };
-
   const removeItem = (id: number) => {
     const newProductData = cartProductList.filter(
       (item: ICartProduct) => item.id !== id
@@ -29,13 +25,32 @@ const SideDrawer = ({
     setCartProductList(newProductData);
   };
 
-  const handleApplyNumberButtonClicked = () => {
-    // todo: POST요청으로 장바구니 데이터 서버에 전달
-    // todo: cartProductsCount의 수량과 cartProductList의 수량의 싱크 맞추기
-
-    console.log("cartProductsCount:", cartProductsCount);
-    console.log("cartProductList:", cartProductList);
+  const findSameItemCount = (id: number) => {
+    const sameItem = cartProductsCount.find((el) => el.id === id);
+    return sameItem?.count;
   };
+
+  const handleCloseButtonClick = () => {
+    setIsSideDrawerClicked(false);
+  };
+
+  const handleApplyNumberButtonClicked = () => {
+    const newCartProductList = cartProductList.map((product) => {
+      if (findSameItemCount(product.id)) {
+        const updatedCount = findSameItemCount(product.id);
+        product = {
+          ...product,
+          count: updatedCount || product.count,
+        };
+      }
+      return product;
+    });
+    setCartProductList(newCartProductList);
+  };
+
+  useEffect(() => {
+    // todo: POST요청으로 장바구니 데이터 서버에 전달
+  }, [cartProductList]);
 
   useEffect(() => {
     const cartItemCountArray = cartProductList.map(

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -51,16 +51,16 @@ const SideDrawer = ({
       return product;
     });
     setCartProductList(newCartProductList);
+    // todo: POST요청으로 장바구니 데이터 서버에 전달.
+    // UpdateCartService(cartProductList);
   };
 
   useEffect(() => {
-    // todo: 500에러남.
+    // todo: 500에러
     // setCartProductList(cartListData);
   }, []);
 
   useEffect(() => {
-    // todo: POST요청으로 장바구니 데이터 서버에 전달. hook안에서 hook이 안불려서 실행이 안됌.
-    // UpdateCartService(cartProductList);
     const cartItemCountArray = cartProductList?.map(
       (cartItem: ISendingCartProduct) => {
         return {
@@ -148,7 +148,7 @@ const SideDrawerItem = ({
   setCartProductsCount,
 }: TDrawerItem) => {
   const [productCount, setProductCount] = useState(
-    cartProductsCount.filter((cartItem) => cartItem.id === productId)[0].count
+    cartProductsCount.filter((cartItem) => cartItem.id === productId)[0]?.count
   );
 
   useEffect(() => {

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -2,15 +2,11 @@ import S from "../CommonStyles";
 import StepperButton from "components/common/Atoms/StepperButton";
 import ProductCard from "../ProductCard";
 import { useRecoilState } from "recoil";
-import { useState, useEffect, SetStateAction } from "react";
+import { useState, useEffect } from "react";
 import { cartProductData } from "stores/CartAtoms";
 import { ICartProduct, ISendingCartProduct } from "types/CartTypes";
+import { TSideDrawer, drawerITemType } from "types/SideDrawerTypes";
 import { Link } from "react-router-dom";
-
-type TSideDrawer = {
-  isSideDrawerClicked: undefined | boolean;
-  setIsSideDrawerClicked: (value: boolean) => void;
-};
 
 const SideDrawer = ({
   isSideDrawerClicked,
@@ -111,19 +107,6 @@ const SideDrawer = ({
       </S.SideDrawer.DrawerBottom>
     </S.SideDrawer.DrawerLayout>
   );
-};
-
-// 장바구니 아이템의 props로 받아올 type들
-// 위에서 map 돌릴 것 같아요
-type drawerITemType = {
-  // productSeller: string
-  productId: number;
-  productImage: string;
-  productName: string;
-  productPrice: number;
-  removeItem: (id: number) => void;
-  cartProductsCount: ISendingCartProduct[];
-  setCartProductsCount: React.Dispatch<SetStateAction<ISendingCartProduct[]>>;
 };
 
 const SideDrawerItem = ({

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -85,7 +85,7 @@ const SideDrawer = ({
         </S.SideDrawer.DrawerCardCloseButton>
       </S.SideDrawer.DrawerHeaderLayer>
       <S.SideDrawer.DrawerCardListLayer>
-        {cartProductsCount.length !== 0 &&
+        {(cartProductsCount.length &&
           cartProductList.map((cartItem) => {
             return (
               <SideDrawerItem
@@ -100,7 +100,13 @@ const SideDrawer = ({
                 setCartProductsCount={setCartProductsCount}
               />
             );
-          })}
+          })) || (
+          <>
+            <S.SideDrawer.EmptyDrawerMessage>
+              장바구니에 상품이 존재하지 않습니다.
+            </S.SideDrawer.EmptyDrawerMessage>
+          </>
+        )}
       </S.SideDrawer.DrawerCardListLayer>
       <S.SideDrawer.DrawerBottom>
         <S.SideDrawer.DrawerTotalPrice>

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -5,7 +5,7 @@ import { useRecoilState } from "recoil";
 import { useState, useEffect } from "react";
 import { cartProductData } from "stores/CartAtoms";
 import { ICartProduct, ISendingCartProduct } from "types/CartTypes";
-import { TSideDrawer, drawerITemType } from "types/SideDrawerTypes";
+import { TSideDrawer, drawerItemType } from "types/SideDrawerTypes";
 import { Link } from "react-router-dom";
 
 const SideDrawer = ({
@@ -132,7 +132,7 @@ const SideDrawerItem = ({
   removeItem,
   cartProductsCount,
   setCartProductsCount,
-}: drawerITemType) => {
+}: drawerItemType) => {
   const [productCount, setProductCount] = useState(
     cartProductsCount.filter((cartItem) => cartItem.id === productId)[0].count
   );

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -37,11 +37,7 @@ const SideDrawer = ({
 
   const handleApplyNumberButtonClicked = () => {
     // todo: POST요청으로 장바구니 데이터 서버에 전달
-  };
-
-  const handleMoveToCartButtonClicked = () => {
-    //cartProductsCount의 수량과 cartProductList의 수량의 싱크 맞추기
-    // todo: cart페이지로 이동
+    // todo: cartProductsCount의 수량과 cartProductList의 수량의 싱크 맞추기
   };
 
   useEffect(() => {
@@ -110,9 +106,7 @@ const SideDrawer = ({
           >
             수량변경
           </S.SideDrawer.ApplyNumbersButton>
-          <S.SideDrawer.DrawerMoveToCartButton
-            onClick={handleMoveToCartButtonClicked}
-          >
+          <S.SideDrawer.DrawerMoveToCartButton>
             <Link to="/cart"> 장바구니로 이동</Link>
           </S.SideDrawer.DrawerMoveToCartButton>
         </S.SideDrawer.ButtonLayer>

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -35,9 +35,12 @@ const SideDrawer = ({
     setCartProductList(newProductData);
   };
 
+  const handleApplyNumberButtonClicked = () => {
+    // todo: POST요청으로 장바구니 데이터 서버에 전달
+  };
+
   const handleMoveToCartButtonClicked = () => {
     //cartProductsCount의 수량과 cartProductList의 수량의 싱크 맞추기
-    // todo: POST요청으로 장바구니 데이터 서버에 전달
     // todo: cart페이지로 이동
   };
 
@@ -102,7 +105,9 @@ const SideDrawer = ({
           (배송비 불포함 금액)
         </S.SideDrawer.DrawerDeliveryFee>
         <S.SideDrawer.ButtonLayer>
-          <S.SideDrawer.ApplyNumbersButton>
+          <S.SideDrawer.ApplyNumbersButton
+            onClick={handleApplyNumberButtonClicked}
+          >
             수량변경
           </S.SideDrawer.ApplyNumbersButton>
           <S.SideDrawer.DrawerMoveToCartButton
@@ -172,7 +177,7 @@ const SideDrawerItem = ({
       </S.SideDrawer.DrawerCardCountDiv>
       <S.SideDrawer.DrawerCardBottom>
         <S.SideDrawer.DrawerCardPrice>
-          총 합: 21400원
+          {`총 합: ${productPrice * productCount}원`}
         </S.SideDrawer.DrawerCardPrice>
         <S.SideDrawer.DrawerCardDeleteButton
           onClick={() => removeItem(productId)}

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -60,7 +60,7 @@ const SideDrawer = ({
 
   useEffect(() => {
     let total = 0;
-    cartProductsCount.forEach(cartItem => {
+    cartProductsCount.forEach((cartItem) => {
       total += cartItem.price * cartItem.count;
     });
     setCartTotalPrice(total);
@@ -79,7 +79,7 @@ const SideDrawer = ({
       </S.SideDrawer.DrawerHeaderLayer>
       <S.SideDrawer.DrawerCardListLayer>
         {cartProductsCount.length !== 0 &&
-          cartProductList.map(cartItem => {
+          cartProductList.map((cartItem) => {
             return (
               <SideDrawerItem
                 // productSeller={} => // todo: API로 교체하면 seller 정보 넣기
@@ -134,7 +134,7 @@ const SideDrawerItem = ({
   setCartProductsCount,
 }: drawerITemType) => {
   const [productCount, setProductCount] = useState(
-    cartProductsCount.filter(cartItem => cartItem.id === productId)[0].count
+    cartProductsCount.filter((cartItem) => cartItem.id === productId)[0].count
   );
 
   useEffect(() => {
@@ -143,7 +143,7 @@ const SideDrawerItem = ({
       price: productPrice,
       count: productCount,
     };
-    const updatedCartProductsCount = cartProductsCount.map(cartItem => {
+    const updatedCartProductsCount = cartProductsCount.map((cartItem) => {
       return cartItem.id === productId ? newCount : cartItem;
     });
     setCartProductsCount(updatedCartProductsCount);
@@ -157,7 +157,6 @@ const SideDrawerItem = ({
           productImg={productImage}
           productName={productName}
           productPrice={productPrice}
-          seller="박크롱" //seller 정보 넣을 것인가
           horizontal={true}
         />
         <S.SideDrawer.DrawerCardDescription>

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -5,7 +5,7 @@ import { useRecoilState } from "recoil";
 import { useState, useEffect, SetStateAction } from "react";
 import { cartProductData } from "stores/CartAtoms";
 import { ICartProduct, ISendingCartProduct } from "types/CartTypes";
-import { GETCartData } from "util/mock/GETCartData";
+// import { GETCartData } from "util/mock/GETCartData";
 import { Link } from "react-router-dom";
 
 type TSideDrawer = {
@@ -17,7 +17,7 @@ const SideDrawer = ({
   isSideDrawerClicked,
   setIsSideDrawerClicked,
 }: TSideDrawer) => {
-  const MockData = GETCartData.data.detail;
+  // const MockData = GETCartData.data.detail; //mock데이터 삭제
   const [cartProductList, setCartProductList] = useRecoilState(cartProductData);
   const [cartProductsCount, setCartProductsCount] = useState<
     ISendingCartProduct[]
@@ -40,9 +40,9 @@ const SideDrawer = ({
     // todo: cartProductsCount의 수량과 cartProductList의 수량의 싱크 맞추기
   };
 
-  useEffect(() => {
-    setCartProductList(MockData);
-  }, []);
+  // useEffect(() => {
+  //   setCartProductList(MockData);
+  // }, []);
 
   useEffect(() => {
     const cartItemCountArray = cartProductList.map(

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -1,6 +1,10 @@
 import S from "../CommonStyles";
 import StepperButton from "components/common/Atoms/StepperButton";
 import ProductCard from "../ProductCard";
+import {
+  CartService,
+  UpdateCartService,
+} from "components/Cart/CartProduct/CartProductsService";
 import { useRecoilState } from "recoil";
 import { useState, useEffect } from "react";
 import { cartProductData } from "stores/CartAtoms";
@@ -12,6 +16,7 @@ const SideDrawer = ({
   isSideDrawerClicked,
   setIsSideDrawerClicked,
 }: TSideDrawer) => {
+  const { cartListData, isLoading } = CartService();
   const [cartProductList, setCartProductList] = useRecoilState(cartProductData);
   const [cartProductsCount, setCartProductsCount] = useState<
     ISendingCartProduct[]
@@ -49,11 +54,14 @@ const SideDrawer = ({
   };
 
   useEffect(() => {
-    // todo: POST요청으로 장바구니 데이터 서버에 전달
-  }, [cartProductList]);
+    // todo: 500에러남.
+    // setCartProductList(cartListData);
+  }, []);
 
   useEffect(() => {
-    const cartItemCountArray = cartProductList.map(
+    // todo: POST요청으로 장바구니 데이터 서버에 전달. hook안에서 hook이 안불려서 실행이 안됌.
+    // UpdateCartService(cartProductList);
+    const cartItemCountArray = cartProductList?.map(
       (cartItem: ISendingCartProduct) => {
         return {
           id: cartItem.id,

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -5,7 +5,6 @@ import { useRecoilState } from "recoil";
 import { useState, useEffect, SetStateAction } from "react";
 import { cartProductData } from "stores/CartAtoms";
 import { ICartProduct, ISendingCartProduct } from "types/CartTypes";
-// import { GETCartData } from "util/mock/GETCartData";
 import { Link } from "react-router-dom";
 
 type TSideDrawer = {
@@ -17,7 +16,6 @@ const SideDrawer = ({
   isSideDrawerClicked,
   setIsSideDrawerClicked,
 }: TSideDrawer) => {
-  // const MockData = GETCartData.data.detail; //mock데이터 삭제
   const [cartProductList, setCartProductList] = useRecoilState(cartProductData);
   const [cartProductsCount, setCartProductsCount] = useState<
     ISendingCartProduct[]
@@ -38,11 +36,10 @@ const SideDrawer = ({
   const handleApplyNumberButtonClicked = () => {
     // todo: POST요청으로 장바구니 데이터 서버에 전달
     // todo: cartProductsCount의 수량과 cartProductList의 수량의 싱크 맞추기
-  };
 
-  // useEffect(() => {
-  //   setCartProductList(MockData);
-  // }, []);
+    console.log("cartProductsCount:", cartProductsCount);
+    console.log("cartProductList:", cartProductList);
+  };
 
   useEffect(() => {
     const cartItemCountArray = cartProductList.map(
@@ -82,6 +79,7 @@ const SideDrawer = ({
             return (
               <SideDrawerItem
                 // productSeller={} => // todo: API로 교체하면 seller 정보 넣기
+                key={`item-${cartItem.id}`}
                 productId={cartItem.id}
                 productImage={cartItem.imageUrl}
                 productName={cartItem.productName}

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -5,7 +5,7 @@ import { useRecoilState } from "recoil";
 import { useState, useEffect } from "react";
 import { cartProductData } from "stores/CartAtoms";
 import { ICartProduct, ISendingCartProduct } from "types/CartTypes";
-import { TSideDrawer, drawerItemType } from "types/SideDrawerTypes";
+import { TSideDrawer, TDrawerItem } from "types/SideDrawerTypes";
 import { Link } from "react-router-dom";
 
 const SideDrawer = ({
@@ -138,7 +138,7 @@ const SideDrawerItem = ({
   removeItem,
   cartProductsCount,
   setCartProductsCount,
-}: drawerItemType) => {
+}: TDrawerItem) => {
   const [productCount, setProductCount] = useState(
     cartProductsCount.filter((cartItem) => cartItem.id === productId)[0].count
   );

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -101,11 +101,16 @@ const SideDrawer = ({
         <S.SideDrawer.DrawerDeliveryFee>
           (배송비 불포함 금액)
         </S.SideDrawer.DrawerDeliveryFee>
-        <S.SideDrawer.DrawerMoveToCartButton
-          onClick={handleMoveToCartButtonClicked}
-        >
-          <Link to="/cart"> 장바구니로 이동</Link>
-        </S.SideDrawer.DrawerMoveToCartButton>
+        <S.SideDrawer.ButtonLayer>
+          <S.SideDrawer.ApplyNumbersButton>
+            수량변경
+          </S.SideDrawer.ApplyNumbersButton>
+          <S.SideDrawer.DrawerMoveToCartButton
+            onClick={handleMoveToCartButtonClicked}
+          >
+            <Link to="/cart"> 장바구니로 이동</Link>
+          </S.SideDrawer.DrawerMoveToCartButton>
+        </S.SideDrawer.ButtonLayer>
       </S.SideDrawer.DrawerBottom>
     </S.SideDrawer.DrawerLayout>
   );

--- a/itda-front/src/components/common/Header/SideDrawer.tsx
+++ b/itda-front/src/components/common/Header/SideDrawer.tsx
@@ -4,6 +4,7 @@ import ProductCard from "../ProductCard";
 import {
   CartService,
   UpdateCartService,
+  DeleteCartService,
 } from "components/Cart/CartProduct/CartProductsService";
 import { useRecoilState } from "recoil";
 import { useState, useEffect } from "react";
@@ -28,6 +29,8 @@ const SideDrawer = ({
       (item: ICartProduct) => item.id !== id
     );
     setCartProductList(newProductData);
+    // todo: 상품이 삭제되면 서버에 삭제요청
+    DeleteCartService(id);
   };
 
   const findSameItemCount = (id: number) => {

--- a/itda-front/src/components/common/ProductCard.tsx
+++ b/itda-front/src/components/common/ProductCard.tsx
@@ -8,7 +8,6 @@ type TProductCardPropType = {
   productImg: string;
   productName: string;
   productPrice: number;
-  seller: string;
   description?: string;
   id?: number;
 };
@@ -29,7 +28,6 @@ const ProductCard = ({
   productImg,
   productName,
   productPrice,
-  seller,
   description = "",
   id,
 }: TProductCardPropType) => {
@@ -43,7 +41,6 @@ const ProductCard = ({
             productImg,
             productName,
             productPrice,
-            seller,
             id,
           }}
         />
@@ -55,7 +52,6 @@ const ProductCard = ({
             productImg,
             productName,
             productPrice,
-            seller,
             description,
             id,
           }}
@@ -71,7 +67,6 @@ const VerticalCard = ({
   productImg,
   productName,
   productPrice,
-  seller,
   description,
   id,
 }: TProductCardPropType) => {
@@ -102,7 +97,6 @@ const VerticalCard = ({
           horizontal={horizontal}
           size={verticalCardSize[size]}
         >
-          <span>{`[${seller}]`}</span>
           <span>{productName}</span>
         </S.ProductCard.ProductTitle>
         <S.ProductCard.ProductDescription>
@@ -124,7 +118,6 @@ const HorizontalCard = ({
   productImg,
   productName,
   productPrice,
-  seller,
   id,
 }: TProductCardPropType) => {
   const horizontalCardSize: TcardSizeType = {
@@ -152,7 +145,7 @@ const HorizontalCard = ({
           horizontal={horizontal}
           size={horizontalCardSize[size]}
         >
-          [{seller}] {productName}
+          {productName}
         </S.ProductCard.ProductTitle>
         <S.ProductCard.ProductPrice
           horizontal={horizontal}

--- a/itda-front/src/types/ProductDetailTypes.ts
+++ b/itda-front/src/types/ProductDetailTypes.ts
@@ -14,6 +14,14 @@ export interface IProductDetail extends ICommonInfo {
   imgUrl: string;
 }
 
+// export interface ITargetProductDetail {
+//   id: number;
+//   imageUrl: string;
+//   productName: string;
+//   price: number;
+//   count: number;
+// }
+
 export interface IReview {
   id: number;
   writer: ICommonWriterInfo;

--- a/itda-front/src/types/SideDrawerTypes.ts
+++ b/itda-front/src/types/SideDrawerTypes.ts
@@ -6,7 +6,7 @@ type TSideDrawer = {
   setIsSideDrawerClicked: (value: boolean) => void;
 };
 
-type drawerITemType = {
+type drawerItemType = {
   // productSeller: string
   productId: number;
   productImage: string;
@@ -17,4 +17,4 @@ type drawerITemType = {
   setCartProductsCount: React.Dispatch<SetStateAction<ISendingCartProduct[]>>;
 };
 
-export type { TSideDrawer, drawerITemType };
+export type { TSideDrawer, drawerItemType };

--- a/itda-front/src/types/SideDrawerTypes.ts
+++ b/itda-front/src/types/SideDrawerTypes.ts
@@ -1,0 +1,20 @@
+import { ISendingCartProduct } from "./CartTypes";
+import { SetStateAction } from "react";
+
+type TSideDrawer = {
+  isSideDrawerClicked: undefined | boolean;
+  setIsSideDrawerClicked: (value: boolean) => void;
+};
+
+type drawerITemType = {
+  // productSeller: string
+  productId: number;
+  productImage: string;
+  productName: string;
+  productPrice: number;
+  removeItem: (id: number) => void;
+  cartProductsCount: ISendingCartProduct[];
+  setCartProductsCount: React.Dispatch<SetStateAction<ISendingCartProduct[]>>;
+};
+
+export type { TSideDrawer, drawerITemType };

--- a/itda-front/src/types/SideDrawerTypes.ts
+++ b/itda-front/src/types/SideDrawerTypes.ts
@@ -6,7 +6,7 @@ type TSideDrawer = {
   setIsSideDrawerClicked: (value: boolean) => void;
 };
 
-type drawerItemType = {
+type TDrawerItem = {
   // productSeller: string
   productId: number;
   productImage: string;
@@ -17,4 +17,4 @@ type drawerItemType = {
   setCartProductsCount: React.Dispatch<SetStateAction<ISendingCartProduct[]>>;
 };
 
-export type { TSideDrawer, drawerItemType };
+export type { TSideDrawer, TDrawerItem };

--- a/itda-front/src/util/API/cartAPI.ts
+++ b/itda-front/src/util/API/cartAPI.ts
@@ -1,1 +1,16 @@
-export {};
+import { ICartProduct } from "types/CartTypes";
+import { instanceWithAuth } from "./index";
+
+const getCartProductList = () => instanceWithAuth.get("/cart");
+
+const updateCartProductList = (productList: ICartProduct[]) =>
+  instanceWithAuth.post("/cart");
+
+const deleteCartProduct = (productId: number) =>
+  instanceWithAuth.delete(`/cart?productId=${productId}`);
+
+export const cartAPI = {
+  get: { getCartProductList },
+  post: { updateCartProductList },
+  delete: { deleteCartProduct },
+};

--- a/itda-front/src/util/API/cartAPI.ts
+++ b/itda-front/src/util/API/cartAPI.ts
@@ -6,7 +6,7 @@ const getCartProductList = () => instanceWithAuth.get("/cart");
 const updateCartProductList = (productList: ICartProduct[]) =>
   instanceWithAuth.post("/cart");
 
-const deleteCartProduct = (productId: number) =>
+const deleteCartProduct = (productId: string) =>
   instanceWithAuth.delete(`/cart?productId=${productId}`);
 
 export const cartAPI = {


### PR DESCRIPTION
## 📌 개요
- Close #178 
SideDrawer하단에 수량변경버튼 추가 + 상세페이지의 장바구니 담기 클릭시 SideDrawer에 반영 + API 적용로직 (부분)구현

## 👩‍💻 작업 사항
- [x] seller정보 삭제 
- [x] `수량변경` 버튼 추가하기 
- [x] mock 데이터 적용해제 
- [x] 상세페이지의 `장바구니 담기` 버튼 클릭 시 sideDrawer에 보여주기
     - [x] 중복상품 추가 방지
- [x] 장바구니에 상품이 없을 경우 비어있다는 메세지 보여주기 
- [x] SideDrawer에 API 붙이기
     - [x] 추가 
     - [x] 수정
     - [x] 삭제

## ✅ 참고 사항
get부터 해보려고 했는데 500에러가 떠서 일단은 코드만 구현해두고 주석처리 해두었습니다!😭 
백엔드 분들이랑 얘기해보니 500이 최초에 데이터가 저장이 되지 않았을 때 아무것도 없다보니 서버 에러가 뜰 가능성이 있더라구요. 그런데 사용자가 장바구니 데이터를 전부 삭제해도 빈 상태를 받아봐야 하니 빈 배열이나 빈 객체를 받는 쪽으로 부탁을 드려놨습니다~!
그런데 일단 cart랑 sideDrawer쪽이랑 API가 각각 필요한 부분에 대해서도 얘기를 해야되다보니 넘 길어질 것 같아서 전체회의 때 다시 안건상정(?) 하기로 했습니다 :) 

<sideDrawer 화면 변경 사항>
![image](https://user-images.githubusercontent.com/65105537/136682532-2c0a5c07-990c-4465-bdec-37fa8bb072eb.png)

