### PR TITLE
[FEAT] MyPage 개인정보수정 페이지 API적용

### DIFF
--- a/itda-front/src/components/Login/KakaoCallback.tsx
+++ b/itda-front/src/components/Login/KakaoCallback.tsx
@@ -9,7 +9,7 @@ const KakaoCallback = ({ history, location }: RouteComponentProps) => {
       let code = params.get("code");
       try {
         const jwtToken = await axios.get(
-          `http://34.125.79.175:8000/api/login/kakao?code=${code}`
+          `http://15.164.97.165:8000/api/login/kakao?code=${code}`
         );
         localStorage.setItem("token", JSON.stringify(jwtToken.data.data.token));
         localStorage.setItem("name", JSON.stringify(jwtToken.data.data.name));

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditAfter.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditAfter.tsx
@@ -55,6 +55,7 @@ const MyInfoEditAfter = () => {
 
   const handleChangeUserInfoButtonClick = () => {
     console.log("회원정보수정 페이지 클릭됌");
+    // myPageAPI.user.updateUserInfo<IUserInfo>(userInfo);
   };
 
   return (

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditAfter.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditAfter.tsx
@@ -1,14 +1,61 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useMutation } from "react-query";
 import TextInput from "components/common/Atoms/TextInput";
 import ColorButton from "components/common/Atoms/ColorButton";
 import theme from "styles/theme";
 import S from "../MyPageStyles";
 import Header from "components/common/Header";
 import MyPageTabs from "../MyPageTab/MyPageTabs";
+import myPageAPI from "util/API/myPageAPI";
+import { StringMappingType } from "typescript";
+
+interface IUserInfo {
+  name: string;
+  telephone: string; //number로 받으면 맨 앞의 0이 8진수 리터럴로 인식됨. string => number 변환할 것.
+  email: string;
+  password: string;
+}
+
+interface IUserInputDate {
+  name: string;
+  telephone: string;
+  email: string;
+  password: string;
+  newPassword: string;
+  newPasswordConfirm: string;
+}
 
 const MyInfoEditAfter = () => {
-  const [testState, setTestState] = useState("");
   const [isSeller, setIsSeller] = useState(true); //임시
+  // api로 받아오는 initial 사용자 정보 - 임시로 mock 데이터 넣어둠.
+  const [userInfo, setUserInfo] = useState<IUserInfo>({
+    name: "홍길동",
+    telephone: "01011112222",
+    email: "roach@test.com",
+    password: "test",
+  });
+  //사용자로부터 입력받는 input 데이터
+  const [userInputData, setUserInputData] = useState<IUserInputDate>({
+    name: userInfo.name,
+    telephone: userInfo.telephone,
+    email: userInfo.email,
+    password: "",
+    newPassword: "",
+    newPasswordConfirm: "",
+  });
+
+  const mutation = useMutation(async () => {
+    myPageAPI.user.checkUserInfo();
+  });
+
+  // todo: 사용자의 정보를 먼저 가져와서 input에 보여줘야 함. 서버 작동하면 살릴 것.
+  // useEffect(() => {
+  //   setUserInfo(mutation.data as any);
+  // }, []);
+
+  const handleChangeUserInfoButtonClick = () => {
+    console.log("회원정보수정 페이지 클릭됌");
+  };
 
   return (
     <>
@@ -37,8 +84,14 @@ const MyInfoEditAfter = () => {
                       size="medium"
                       width="50%"
                       isRequired={true}
-                      state={testState}
-                      setState={setTestState}
+                      value={userInputData.password}
+                      state={userInputData.password}
+                      setState={(userInput) =>
+                        setUserInputData({
+                          ...userInputData,
+                          password: userInput,
+                        })
+                      }
                     />
                   </S.MyInfoAfter.CurrentPasswordBlock>
                   <S.MyInfoAfter.NewPasswordBlock>
@@ -51,8 +104,14 @@ const MyInfoEditAfter = () => {
                       size="medium"
                       width="50%"
                       isRequired={true}
-                      state={testState}
-                      setState={setTestState}
+                      value={userInputData.newPassword}
+                      state={userInputData.newPassword}
+                      setState={(userInput) =>
+                        setUserInputData({
+                          ...userInputData,
+                          newPassword: userInput,
+                        })
+                      }
                     />
                   </S.MyInfoAfter.NewPasswordBlock>
                   <S.MyInfoAfter.NewPasswordConfirmBlock>
@@ -65,8 +124,14 @@ const MyInfoEditAfter = () => {
                       size="medium"
                       width="50%"
                       isRequired={true}
-                      state={testState}
-                      setState={setTestState}
+                      value={userInputData.newPasswordConfirm}
+                      state={userInputData.newPasswordConfirm}
+                      setState={(userInput) => {
+                        setUserInputData({
+                          ...userInputData,
+                          newPasswordConfirm: userInput,
+                        });
+                      }}
                     />
                   </S.MyInfoAfter.NewPasswordConfirmBlock>
                   <S.MyInfoAfter.NameBlock>
@@ -77,8 +142,14 @@ const MyInfoEditAfter = () => {
                       size="medium"
                       width="50%"
                       isRequired={true}
-                      state={testState}
-                      setState={setTestState}
+                      value={userInputData.name}
+                      state={userInputData.name}
+                      setState={(userInput) => {
+                        setUserInputData({
+                          ...userInputData,
+                          name: userInput,
+                        });
+                      }}
                     />
                   </S.MyInfoAfter.NameBlock>
                   <S.MyInfoAfter.EmailBlock>
@@ -89,8 +160,14 @@ const MyInfoEditAfter = () => {
                       size="medium"
                       width="50%"
                       isRequired={true}
-                      state={testState}
-                      setState={setTestState}
+                      value={userInputData.email}
+                      state={userInputData.email}
+                      setState={(userInput) => {
+                        setUserInputData({
+                          ...userInputData,
+                          email: userInput,
+                        });
+                      }}
                     />
                   </S.MyInfoAfter.EmailBlock>
                   <S.MyInfoAfter.CellPhoneNumberBlock>
@@ -103,12 +180,19 @@ const MyInfoEditAfter = () => {
                       size="medium"
                       width="50%"
                       isRequired={true}
-                      state={testState}
-                      setState={setTestState}
+                      value={userInputData.telephone}
+                      state={userInputData.telephone}
+                      setState={(userInput) => {
+                        setUserInputData({
+                          ...userInputData,
+                          telephone: userInput,
+                        });
+                      }}
                     />
                   </S.MyInfoAfter.CellPhoneNumberBlock>
                 </S.MyInfoAfter.FormInputsLayer>
                 <S.MyInfoAfter.FormButtonsLayer>
+                  {/* todo: 중복확인 로직 필요 */}
                   <S.MyInfoAfter.EmailCheckButton variant="outlined">
                     중복확인
                   </S.MyInfoAfter.EmailCheckButton>
@@ -131,6 +215,7 @@ const MyInfoEditAfter = () => {
                   baseColor={theme.colors.navy.light}
                   width={"20%"}
                   fontSize={theme.fontSizes.lg}
+                  onClickButton={handleChangeUserInfoButtonClick}
                 >
                   회원정보수정
                 </ColorButton>

--- a/itda-front/src/components/MyPage/MyPageStyles.ts
+++ b/itda-front/src/components/MyPage/MyPageStyles.ts
@@ -34,7 +34,6 @@ const S = {
     SideTabLayout: styled.div``,
 
     ContentLayout: styled.div`
-      z-index: -1;
       width: 100%;
       height: 100%;
       padding: 3rem;

--- a/itda-front/src/components/common/Atoms/TextInput.tsx
+++ b/itda-front/src/components/common/Atoms/TextInput.tsx
@@ -1,6 +1,7 @@
 import S from "./AtomsStyles";
 
 type TTextInput = {
+  value?: string;
   label?: string | number;
   variant?: "outlined" | "filled" | "standard";
   size?: "small" | "medium";
@@ -11,6 +12,7 @@ type TTextInput = {
 };
 
 const TextInput = ({
+  value,
   label,
   size = "small", //size가 아닌 height로는 높이 조정이 불가능해서 주어진 높이 관련 속성인 size로 정했습니다.
   variant = "outlined",
@@ -30,6 +32,7 @@ const TextInput = ({
 
   return (
     <S.TextInput
+      value={value}
       error={handleEmptyInput()}
       type="text"
       label={label}

--- a/itda-front/src/util/API/index.ts
+++ b/itda-front/src/util/API/index.ts
@@ -4,7 +4,7 @@ import { setInterceptors } from "./common/interceptors";
 
 const createInstance = (isWithAuth: boolean) => {
   const instance = axios.create({
-    baseURL: "http://34.125.79.175:8000/api",
+    baseURL: "http://15.164.97.165:8000/api",
   });
   return setInterceptors(instance, isWithAuth);
 };

--- a/itda-front/src/util/API/myPageAPI.ts
+++ b/itda-front/src/util/API/myPageAPI.ts
@@ -7,7 +7,8 @@ const checkReview = async () => instanceWithAuth.get("/myPage/reviews");
 
 const checkUserInfo = async () => instanceWithAuth.get("/myPage/user");
 
-const updateUserInfo = async () => instanceWithAuth.post("/myPage/user");
+const updateUserInfo = async (newUserInfo: any) =>
+  instanceWithAuth.post("/myPage/user", newUserInfo);
 
 const myPageAPI = {
   seller: { addNewProduct },

--- a/itda-front/src/util/API/myPageAPI.ts
+++ b/itda-front/src/util/API/myPageAPI.ts
@@ -5,10 +5,16 @@ const addNewProduct = async (newProduct: any) =>
 
 const checkReview = async () => instanceWithAuth.get("/myPage/reviews");
 
+const checkUserInfo = async () => instanceWithAuth.get("/myPage/user");
+
+const updateUserInfo = async () => instanceWithAuth.post("/myPage/user");
+
 const myPageAPI = {
   seller: { addNewProduct },
   user: {
     checkReview,
+    checkUserInfo,
+    updateUserInfo,
   },
 };
 


### PR DESCRIPTION
## 📌 개요

- Close #198 
- MyPage의 개인정보수정 페이지에 API 붙이기

## 👩‍💻 작업 사항

- [x] 개인정보수정 페이지(기본 정보) API 적용
    - [x] GET 적용
    - [x] POST 적용
- [x] common > TextInput.tsx 에 value 프로퍼티 추가

## ✅ 참고 사항

![image](https://user-images.githubusercontent.com/65105537/137625342-e87a1165-2c22-4454-8c28-ed7a35ce62ad.png)
