### PR TITLE
[FEAT] MyPage 기본정보수정 페이지 validation 로직 구현

### DIFF
--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
@@ -5,7 +5,6 @@ import { myInfoErrorData } from 'stores/MyPageAtoms';
 import { useMutation } from "react-query";
 import myPageAPI from "util/API/myPageAPI";
 import {IUserInfo, IUserInputDate} from 'types/MyInfoTypes';
-import TextInput from "components/common/Atoms/TextInput";
 import ColorButton from "components/common/Atoms/ColorButton";
 import theme from "styles/theme";
 
@@ -71,6 +70,7 @@ const MyInfoEditForm = () => {
                     <S.MyInfoAfter.CurrentPasswordInput
                       required
                       name="currentPassword"
+                      type="password"
                       label="현재 비밀번호를 입력해주세요."
                       placeholder="Example1234"
                       variant="outlined"
@@ -89,6 +89,7 @@ const MyInfoEditForm = () => {
                     <S.MyInfoAfter.NewPasswordInput
                       required
                       name="newPassword"
+                      type="password"
                       label="새롭게 설정할 비밀번호를 입력해주세요."
                       placeholder="Example5678"
                       variant="outlined"
@@ -107,6 +108,7 @@ const MyInfoEditForm = () => {
                     <S.MyInfoAfter.NewPasswordConfirmInput
                       required
                       name="newPasswordConfirm"
+                      type="password"
                       label="새롭게 설정할 비밀번호를 다시 한번 입력해주세요."
                       placeholder="Example5678"
                       variant="outlined"

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
@@ -72,6 +72,17 @@ const MyInfoEditForm = () => {
     setMyInfoError(inputError as IUserInputDate);
   }
 
+  const handleDuplicateCheckButtonClick = () => {
+    // todo: 입력된 데이터 서버에 전송해서 중복검사 결과 보여주기 (아마도 post)
+    const isDuplicateEmail = true; // 임시
+    if (isDuplicateEmail) {
+      setMyInfoError({
+        ...myInfoError,
+        email: "중복 되는 이메일 입니다. 다른 이메일 주소를 입력하세요."
+      })
+    }
+  }
+
 
   const handleChangeUserInfoButtonClick = () => {
     console.log("회원정보수정 페이지 클릭됌");
@@ -118,6 +129,8 @@ const MyInfoEditForm = () => {
                       placeholder="Example5678"
                       variant="outlined"
                       onChange={handleMyInfoFormChange}
+                      error={myInfoError.newPassword !== ''}
+                      helperText={myInfoError.newPassword}
                     />
                   </S.MyInfoAfter.NewPasswordBlock>
                   <S.MyInfoAfter.NewPasswordConfirmBlock>
@@ -145,6 +158,8 @@ const MyInfoEditForm = () => {
                     value={userInputData.name && userInputData.name}
                     variant="outlined"
                     onChange={handleMyInfoFormChange}
+                    error={myInfoError.name !== ''}
+                    helperText={myInfoError.name}
                     />
                   </S.MyInfoAfter.NameBlock>
                   <S.MyInfoAfter.EmailBlock>
@@ -156,6 +171,8 @@ const MyInfoEditForm = () => {
                     value={userInputData.email && userInputData.email}
                     variant="outlined"
                     onChange={handleMyInfoFormChange}
+                    error={myInfoError.email !== ''}
+                    helperText={myInfoError.email}
                     />
                   </S.MyInfoAfter.EmailBlock>
                   <S.MyInfoAfter.CellPhoneNumberBlock>
@@ -169,12 +186,15 @@ const MyInfoEditForm = () => {
                     value={userInputData.telephone && userInputData.telephone}
                     variant="outlined"
                     onChange={handleMyInfoFormChange}
+                    error={myInfoError.telephone !== ''}
+                    helperText={myInfoError.telephone}
                     />
                   </S.MyInfoAfter.CellPhoneNumberBlock>
                 </S.MyInfoAfter.FormInputsLayer>
                 <S.MyInfoAfter.FormButtonsLayer>
-                  {/* todo: 중복확인 로직 필요 */}
-                  <S.MyInfoAfter.EmailCheckButton variant="outlined">
+                  <S.MyInfoAfter.EmailCheckButton
+                    variant="outlined"
+                    onClick={handleDuplicateCheckButtonClick}>
                     중복확인
                   </S.MyInfoAfter.EmailCheckButton>
                   <S.MyInfoAfter.CellPhoneNumberCheckButton>

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
@@ -32,24 +32,30 @@ const MyInfoEditForm = () => {
     myPageAPI.user.checkUserInfo();
   });
 
-  const validateInputdata = (args: IUserInputDate ) => {
+  const validateInputdata = (inputName:string, inputValue:string) => {
       const errors ={};
+      console.log("에러를 만들어요.")
       return errors;
-  }
-
-  const handleMyInfoFormChange = (e: React.ChangeEvent<any>) => {
-    const { name, value } = e.target;
-
-    const inputErrors = validateInputdata(userInputData);
-    // setUserInputData(userInputData[value]) //todo: userInputData에서 해당하는 key를 찾아서 value를 업데이트 하고, 업데이트 된 객체를 다시 set해줘야 함.
-
-    setMyInfoError(inputErrors as IUserInputDate);
   }
 
   // todo: 사용자의 정보를 먼저 가져와서 input에 보여줘야 함. 서버 작동하면 살릴 것.
   // useEffect(() => {
   //   setUserInfo(mutation.data as any);
   // }, []);
+
+  //todo: 여기서 하는 일: 에러검사, 에러메세지 보여주고 userInputData에서 해당하는 상태 업데이트
+  const handleMyInfoFormChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    setUserInputData({
+      ...userInputData,
+      [name]: value
+    })
+    console.log(userInputData)
+    const inputErrors = validateInputdata(name, value);
+    setMyInfoError(inputErrors as IUserInputDate);
+  }
+
 
   const handleChangeUserInfoButtonClick = () => {
     console.log("회원정보수정 페이지 클릭됌");
@@ -69,17 +75,14 @@ const MyInfoEditForm = () => {
                     </S.MyInfoAfter.CurrentPasswordLabel>
                     <S.MyInfoAfter.CurrentPasswordInput
                       required
-                      name="currentPassword"
+                      name="password"
                       type="password"
                       label="현재 비밀번호를 입력해주세요."
                       placeholder="Example1234"
                       variant="outlined"
-                      onChange={(e) => {
-                        setUserInputData({
-                          ...userInputData,
-                          password: e.target.value,
-                        });
-                      }}
+                      onChange={handleMyInfoFormChange}
+                      error={userInputData.password === ""}
+                      helperText="에러메세지가 나오는 곳"
                     />
                   </S.MyInfoAfter.CurrentPasswordBlock>
                   <S.MyInfoAfter.NewPasswordBlock>
@@ -93,12 +96,7 @@ const MyInfoEditForm = () => {
                       label="새롭게 설정할 비밀번호를 입력해주세요."
                       placeholder="Example5678"
                       variant="outlined"
-                      onChange={(e) => {
-                        setUserInputData({
-                          ...userInputData,
-                          newPassword: e.target.value,
-                        })
-                      }}
+                      onChange={handleMyInfoFormChange}
                     />
                   </S.MyInfoAfter.NewPasswordBlock>
                   <S.MyInfoAfter.NewPasswordConfirmBlock>
@@ -125,12 +123,7 @@ const MyInfoEditForm = () => {
                     label="이름을 입력해주세요."
                     value={userInputData.name && userInputData.name}
                     variant="outlined"
-                    onChange={(e) => {
-                      setUserInputData({
-                        ...userInputData,
-                        name: e.target.value
-                      })
-                    }}
+                    onChange={handleMyInfoFormChange}
                     />
                   </S.MyInfoAfter.NameBlock>
                   <S.MyInfoAfter.EmailBlock>
@@ -141,12 +134,7 @@ const MyInfoEditForm = () => {
                     label="이메일을 입력해주세요."
                     value={userInputData.email && userInputData.email}
                     variant="outlined"
-                    onChange={(e) => {
-                      setUserInputData({
-                        ...userInputData,
-                        email: e.target.value
-                      })
-                    }}
+                    onChange={handleMyInfoFormChange}
                     />
                   </S.MyInfoAfter.EmailBlock>
                   <S.MyInfoAfter.CellPhoneNumberBlock>
@@ -155,16 +143,11 @@ const MyInfoEditForm = () => {
                     </S.MyInfoAfter.CellPhoneNumberLabel>
                     <S.MyInfoAfter.CellPhoneNumberInput
                     required
-                    name="cellphone"
+                    name="telephone"
                     label="휴대폰 번호를 입력해주세요."
                     value={userInputData.telephone && userInputData.telephone}
                     variant="outlined"
-                    onChange={(e) => {
-                      setUserInputData({
-                        ...userInputData,
-                        telephone: e.target.value
-                      })
-                    }}
+                    onChange={handleMyInfoFormChange}
                     />
                   </S.MyInfoAfter.CellPhoneNumberBlock>
                 </S.MyInfoAfter.FormInputsLayer>

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
@@ -9,7 +9,14 @@ import ColorButton from "components/common/Atoms/ColorButton";
 import theme from "styles/theme";
 
 const MyInfoEditForm = () => {
-  const [myInfoError, setMyInfoError] = useRecoilState<IUserInputDate>(myInfoErrorData)
+  const [myInfoError, setMyInfoError] = useState<IUserInputDate>({
+    name: "",
+    telephone: "",
+    email: "",
+    password: "",
+    newPassword: "",
+    newPasswordConfirm: ""
+  })
   // !--------api로 받아오는 initial 사용자 정보 - 임시 mock 데이터. 실제 api가져오는 로직으로 바꿔야함.
   const [userInfo, setUserInfo] = useState<IUserInfo>({
     name: "홍길동",
@@ -33,17 +40,17 @@ const MyInfoEditForm = () => {
   });
 
   const validateInputdata = (inputName:string, inputValue:string) => {
-      const errors ={};
-      console.log("에러를 만들어요.")
+      const errors = myInfoError;
+
+      if (inputName === "password") {
+        // todo: 서버에서 비밀번호 가져와서 비교하는 로직 필요할
+        const curPassword = "test1234" // 서버 비밀번호 대체. 임시.
+        errors[inputName] = (curPassword === inputValue ? '' : "비밀번호가 일치하지 않습니다.");
+      }
+
       return errors;
   }
 
-  // todo: 사용자의 정보를 먼저 가져와서 input에 보여줘야 함. 서버 작동하면 살릴 것.
-  // useEffect(() => {
-  //   setUserInfo(mutation.data as any);
-  // }, []);
-
-  //todo: 여기서 하는 일: 에러검사, 에러메세지 보여주고 userInputData에서 해당하는 상태 업데이트
   const handleMyInfoFormChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
 
@@ -51,9 +58,9 @@ const MyInfoEditForm = () => {
       ...userInputData,
       [name]: value
     })
-    console.log(userInputData)
-    const inputErrors = validateInputdata(name, value);
-    setMyInfoError(inputErrors as IUserInputDate);
+
+    const inputError = validateInputdata(name, value);
+    setMyInfoError(inputError as IUserInputDate);
   }
 
 
@@ -61,6 +68,11 @@ const MyInfoEditForm = () => {
     console.log("회원정보수정 페이지 클릭됌");
     // myPageAPI.user.updateUserInfo<IUserInfo>(userInfo);
   };
+
+  // todo: 사용자의 정보를 먼저 가져와서 input에 보여줘야 함. 서버 작동하면 살릴 것.
+  // useEffect(() => {
+  //   setUserInfo(mutation.data as any);
+  // }, []);
 
     return (
         <>
@@ -81,8 +93,8 @@ const MyInfoEditForm = () => {
                       placeholder="Example1234"
                       variant="outlined"
                       onChange={handleMyInfoFormChange}
-                      error={userInputData.password === ""}
-                      helperText="에러메세지가 나오는 곳"
+                      error={myInfoError.password !== ''}
+                      helperText={myInfoError.password}
                     />
                   </S.MyInfoAfter.CurrentPasswordBlock>
                   <S.MyInfoAfter.NewPasswordBlock>

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
@@ -57,6 +57,10 @@ const MyInfoEditForm = () => {
         errors.newPasswordConfirm = (userInputData.newPassword === inputValue  ? '' : "입력하신 정보가 새로운 비밀번호와 일치하지 않습니다.");
       }
 
+      if (inputName === "email") {
+        if (inputValue === "") errors.email = '';
+      }
+
       return errors;
   }
 
@@ -75,10 +79,19 @@ const MyInfoEditForm = () => {
   const handleDuplicateCheckButtonClick = () => {
     // todo: 입력된 데이터 서버에 전송해서 중복검사 결과 보여주기 (아마도 post)
     const isDuplicateEmail = true; // 임시
+    const emailRegex = /\S+@\S+\.\S+/;
+
     if (isDuplicateEmail) {
       setMyInfoError({
         ...myInfoError,
         email: "중복 되는 이메일 입니다. 다른 이메일 주소를 입력하세요."
+      })
+    }
+
+    if (!emailRegex.test(userInputData.email)) {
+      setMyInfoError({
+        ...myInfoError,
+        email: "이메일 주소 형식이 올바르지 않습니다."
       })
     }
   }
@@ -217,4 +230,4 @@ const MyInfoEditForm = () => {
     )
 }
 
-export default MyInfoEditForm
+export default MyInfoEditForm;

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
@@ -45,7 +45,16 @@ const MyInfoEditForm = () => {
       if (inputName === "password") {
         // todo: 서버에서 비밀번호 가져와서 비교하는 로직 필요할
         const curPassword = "test1234" // 서버 비밀번호 대체. 임시.
-        errors[inputName] = (curPassword === inputValue ? '' : "비밀번호가 일치하지 않습니다.");
+        errors.password = (curPassword === inputValue ? '' : "비밀번호가 일치하지 않습니다.");
+      }
+
+      if (inputName === "newPassword" && userInputData.newPasswordConfirm !== '') {
+        errors.newPasswordConfirm = (inputValue === userInputData.newPasswordConfirm ? '' : "입력하신 정보가 새로운 비밀번호와 일치하지 않습니다.");
+        errors.newPasswordConfirm = (inputValue === '' ? '' : errors.newPasswordConfirm);
+      }
+
+      if (inputName === "newPasswordConfirm" && userInputData.newPassword !== '') {
+        errors.newPasswordConfirm = (userInputData.newPassword === inputValue  ? '' : "입력하신 정보가 새로운 비밀번호와 일치하지 않습니다.");
       }
 
       return errors;
@@ -122,9 +131,9 @@ const MyInfoEditForm = () => {
                       label="새롭게 설정할 비밀번호를 다시 한번 입력해주세요."
                       placeholder="Example5678"
                       variant="outlined"
-                      onChange={(e) => {
-                       // TODO: newPassword랑 같은지 검사하는 로직 필요
-                      }}
+                      onChange={handleMyInfoFormChange}
+                      error={myInfoError.newPasswordConfirm !== ''}
+                      helperText={myInfoError.newPasswordConfirm}
                     />
                   </S.MyInfoAfter.NewPasswordConfirmBlock>
                   <S.MyInfoAfter.NameBlock>

--- a/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
+++ b/itda-front/src/components/MyPage/MyPageInfo/MyInfoEditForm.tsx
@@ -1,5 +1,7 @@
 import S from "../MyPageStyles";
-import { useState} from "react";
+import React, { useState} from "react";
+import { useRecoilState } from "recoil";
+import { myInfoErrorData } from 'stores/MyPageAtoms';
 import { useMutation } from "react-query";
 import myPageAPI from "util/API/myPageAPI";
 import {IUserInfo, IUserInputDate} from 'types/MyInfoTypes';
@@ -8,7 +10,8 @@ import ColorButton from "components/common/Atoms/ColorButton";
 import theme from "styles/theme";
 
 const MyInfoEditForm = () => {
-  // api로 받아오는 initial 사용자 정보 - 임시로 mock 데이터 넣어둠.
+  const [myInfoError, setMyInfoError] = useRecoilState<IUserInputDate>(myInfoErrorData)
+  // !--------api로 받아오는 initial 사용자 정보 - 임시 mock 데이터. 실제 api가져오는 로직으로 바꿔야함.
   const [userInfo, setUserInfo] = useState<IUserInfo>({
     name: "홍길동",
     telephone: "01011112222",
@@ -16,7 +19,7 @@ const MyInfoEditForm = () => {
     password: "test",
   });
 
-  //사용자로부터 입력받는 input 데이터
+  //사용자로부터 입력받는 input 데이터 (input들의 상태를 관리)
   const [userInputData, setUserInputData] = useState<IUserInputDate>({
     name: userInfo.name,
     telephone: userInfo.telephone,
@@ -29,6 +32,20 @@ const MyInfoEditForm = () => {
   const myInfoEditMutation = useMutation(async () => {
     myPageAPI.user.checkUserInfo();
   });
+
+  const validateInputdata = (args: IUserInputDate ) => {
+      const errors ={};
+      return errors;
+  }
+
+  const handleMyInfoFormChange = (e: React.ChangeEvent<any>) => {
+    const { name, value } = e.target;
+
+    const inputErrors = validateInputdata(userInputData);
+    // setUserInputData(userInputData[value]) //todo: userInputData에서 해당하는 key를 찾아서 value를 업데이트 하고, 업데이트 된 객체를 다시 set해줘야 함.
+
+    setMyInfoError(inputErrors as IUserInputDate);
+  }
 
   // todo: 사용자의 정보를 먼저 가져와서 input에 보여줘야 함. 서버 작동하면 살릴 것.
   // useEffect(() => {
@@ -57,14 +74,12 @@ const MyInfoEditForm = () => {
                       label="현재 비밀번호를 입력해주세요."
                       placeholder="Example1234"
                       variant="outlined"
-                      // value={userInputData.password}
-                      // state={userInputData.password}
-                      // setState={(userInput) =>
-                      //   setUserInputData({
-                      //     ...userInputData,
-                      //     password: userInput,
-                      //   }) 
-                      // }
+                      onChange={(e) => {
+                        setUserInputData({
+                          ...userInputData,
+                          password: e.target.value,
+                        });
+                      }}
                     />
                   </S.MyInfoAfter.CurrentPasswordBlock>
                   <S.MyInfoAfter.NewPasswordBlock>
@@ -77,14 +92,12 @@ const MyInfoEditForm = () => {
                       label="새롭게 설정할 비밀번호를 입력해주세요."
                       placeholder="Example5678"
                       variant="outlined"
-                      // value={userInputData.newPassword}
-                      // state={userInputData.newPassword}
-                      // setState={(userInput) =>
-                      //   setUserInputData({
-                      //     ...userInputData,
-                      //     newPassword: userInput,
-                      //   })
-                      // }
+                      onChange={(e) => {
+                        setUserInputData({
+                          ...userInputData,
+                          newPassword: e.target.value,
+                        })
+                      }}
                     />
                   </S.MyInfoAfter.NewPasswordBlock>
                   <S.MyInfoAfter.NewPasswordConfirmBlock>
@@ -97,70 +110,59 @@ const MyInfoEditForm = () => {
                       label="새롭게 설정할 비밀번호를 다시 한번 입력해주세요."
                       placeholder="Example5678"
                       variant="outlined"
-                      // value={userInputData.newPasswordConfirm}
-                      // state={userInputData.newPasswordConfirm}
-                      // setState={(userInput) => {
-                      //   setUserInputData({
-                      //     ...userInputData,
-                      //     newPasswordConfirm: userInput,
-                      //   });
-                      // }}
+                      onChange={(e) => {
+                       // TODO: newPassword랑 같은지 검사하는 로직 필요
+                      }}
                     />
                   </S.MyInfoAfter.NewPasswordConfirmBlock>
                   <S.MyInfoAfter.NameBlock>
                     <S.MyInfoAfter.NameLabel>이름</S.MyInfoAfter.NameLabel>
-                    <TextInput
-                      label="이름을 입력해주세요."
-                      variant="outlined"
-                      size="medium"
-                      width="50%"
-                      isRequired={true}
-                      value={userInputData.name}
-                      state={userInputData.name}
-                      setState={(userInput) => {
-                        setUserInputData({
-                          ...userInputData,
-                          name: userInput,
-                        });
-                      }}
+                    <S.MyInfoAfter.NameInput
+                    required
+                    name="name"
+                    label="이름을 입력해주세요."
+                    value={userInputData.name && userInputData.name}
+                    variant="outlined"
+                    onChange={(e) => {
+                      setUserInputData({
+                        ...userInputData,
+                        name: e.target.value
+                      })
+                    }}
                     />
                   </S.MyInfoAfter.NameBlock>
                   <S.MyInfoAfter.EmailBlock>
                     <S.MyInfoAfter.EmailLabel>이메일</S.MyInfoAfter.EmailLabel>
-                    <TextInput
-                      label="이메일을 입력해주세요."
-                      variant="outlined"
-                      size="medium"
-                      width="50%"
-                      isRequired={true}
-                      value={userInputData.email}
-                      state={userInputData.email}
-                      setState={(userInput) => {
-                        setUserInputData({
-                          ...userInputData,
-                          email: userInput,
-                        });
-                      }}
+                    <S.MyInfoAfter.EmailInput
+                    required
+                    name="email"
+                    label="이메일을 입력해주세요."
+                    value={userInputData.email && userInputData.email}
+                    variant="outlined"
+                    onChange={(e) => {
+                      setUserInputData({
+                        ...userInputData,
+                        email: e.target.value
+                      })
+                    }}
                     />
                   </S.MyInfoAfter.EmailBlock>
                   <S.MyInfoAfter.CellPhoneNumberBlock>
                     <S.MyInfoAfter.CellPhoneNumberLabel>
                       휴대폰
                     </S.MyInfoAfter.CellPhoneNumberLabel>
-                    <TextInput
-                      label="휴대폰 번호를 입력해주세요."
-                      variant="outlined"
-                      size="medium"
-                      width="50%"
-                      isRequired={true}
-                      value={userInputData.telephone}
-                      state={userInputData.telephone}
-                      setState={(userInput) => {
-                        setUserInputData({
-                          ...userInputData,
-                          telephone: userInput,
-                        });
-                      }}
+                    <S.MyInfoAfter.CellPhoneNumberInput
+                    required
+                    name="cellphone"
+                    label="휴대폰 번호를 입력해주세요."
+                    value={userInputData.telephone && userInputData.telephone}
+                    variant="outlined"
+                    onChange={(e) => {
+                      setUserInputData({
+                        ...userInputData,
+                        telephone: e.target.value
+                      })
+                    }}
                     />
                   </S.MyInfoAfter.CellPhoneNumberBlock>
                 </S.MyInfoAfter.FormInputsLayer>

--- a/itda-front/src/components/MyPage/MyPageStyles.ts
+++ b/itda-front/src/components/MyPage/MyPageStyles.ts
@@ -330,6 +330,11 @@ const S = {
       width: 30%;
     `,
 
+    //todo: bootstrap input으로 교체 - name
+    NameInput: styled(TextField)`
+      width: 50%;
+    `,
+
     EmailBlock: styled.div`
       ${inputBlockStyle}
     `,
@@ -337,6 +342,11 @@ const S = {
     EmailLabel: styled.div`
       text-align: left;
       width: 30%;
+    `,
+
+    //todo: bootstrap input으로 교체 - email
+    EmailInput: styled(TextField)`
+      width: 50%;
     `,
 
     EmailCheckButton: styled(Button)`
@@ -353,6 +363,11 @@ const S = {
     CellPhoneNumberLabel: styled.div`
       text-align: left;
       width: 30%;
+    `,
+
+    //todo: bootstrap input으로 교체 - cellphone number
+    CellPhoneNumberInput: styled(TextField)`
+      width: 50%;
     `,
 
     CellPhoneNumberCheckButton: styled(Button)`


### PR DESCRIPTION
## 📌 개요
- Close #210 
- 기본정보수정 페이지에 필요한 validation 로직구현 (중복확인, 비밀번호 대조 등) 및 에러메세지 UI에 노출 기능 추가

## 👩‍💻 작업 사항
- [x] 기존 비밀번호와 입력한 비밀번호 일치 확인 로직 추가 (API 적용 필요)
- [x] 비밀번호 암호화 & 에러메세지 보이도록 UI 수정 
- [x] 새로운 비밀번호와 비밀번호 확인 입력값 비교 로직 구현
- [x] 이메일 중복확인 로직 구현 (API 적용 필요)

## ✅ 참고 사항
< 현재 비밀번호 확인 > 
![image](https://user-images.githubusercontent.com/65105537/139561770-82a68fe9-5acb-47fb-81fd-d75860942535.png)

< 새 비밀번호 일치여부 확인 >
![image](https://user-images.githubusercontent.com/65105537/139561787-f072ad35-cc8c-47b0-8bb5-1499fdf1678d.png)
< 이메일 중복확인 > 
![image](https://user-images.githubusercontent.com/65105537/139561799-0731aa42-76d1-4fe6-b218-c3eb3d00ff9b.png)
![image](https://user-images.githubusercontent.com/65105537/139561804-4c2cd173-8442-4e85-bfab-e814929ced9f.png)
